### PR TITLE
Avoid padding error when using an encoded Azure Storage Services key

### DIFF
--- a/scripts/prepdocs.ps1
+++ b/scripts/prepdocs.ps1
@@ -8,5 +8,6 @@ foreach ($line in $output) {
 
 Write-Host "Environment variables set."
 
-pip install -r ./scripts/requirements.txt
+pip install -r ./scripts/requirements.txt --quiet
+# Add if having Azure authentication issues: --searchkey $env:AZURE_SEARCH_KEY  --storagekey $env:AZURE_STORAGE_KEY
 python ./scripts/prepdocs.py './data/*' --storageaccount $env:AZURE_STORAGE_ACCOUNT --container $env:AZURE_STORAGE_CONTAINER --searchservice $env:AZURE_SEARCH_SERVICE --index $env:AZURE_SEARCH_INDEX -v

--- a/scripts/prepdocs.py
+++ b/scripts/prepdocs.py
@@ -36,9 +36,9 @@ args = parser.parse_args()
 
 # Use the current user identity to connect to Azure services unless a key is explicitly set for any of them
 default_creds = DefaultAzureCredential() if args.searchkey == None or args.storagekey == None else None
-search_creds = default_creds if args.searchkey == None else AzureKeyCredential(args.searchkey)
+search_creds = default_creds if args.searchkey == None else AzureKeyCredential(args.searchkey.strip())
 if not args.skipblobs:
-    storage_creds = default_creds if args.storagekey == None else args.storagekey
+    storage_creds = default_creds if args.storagekey == None else args.storagekey.strip().strip("=")+"=="
 
 def blob_name_from_file_page(filename, page):
     return os.path.splitext(os.path.basename(filename))[0] + f"-{page}" + ".pdf"


### PR DESCRIPTION
## Purpose
Corrects an issue where the environment variable preprocessing may remove the trailing "==" of an encoded key (which was obtained from the Azure Storage Service, in encoded format). This happens when the **AZURE_STORAGE_KEY** environment variable is set on **.azure/**<_environment name_>**/.env**.

The change ensures that the storage key is properly terminated and avoids an **Incorrect padding** error on **binascii.a2b_base64()** while trying to create the credentials to connect to the service. If and when this happens the upload fails and the whole script is aborted; nothing is uploaded.

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```


* Test the code

Prep work:
Execute azd provision in order to create the infrastructure.
Once the services have been created, obtain the Cognitive Search Service key and Storage Service key. Use the main admin keys to be certain.
Add the environment variables AZURE_STORAGE_KEY and AZURE_SEARCH_KEY to the **.azure/**<_environment name_>**/.env** file, and populate with the values obtained. Preferrably use quotes for the values.

Test:
```
execute **scripts/prepdocs.ps1** on the PowerShell environment -or- **azd up**
``` 


## What to Check
Blobs have been uploaded to **container** on Storage Services, and an index has been created in Search Services.