### PR TITLE
Fix Type Alias in Python 3.8

### DIFF
--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -3,6 +3,8 @@ from azure.search.documents import SearchClient
 from azure.search.documents.models import QueryType
 from approaches.approach import Approach
 from text import nonewlines
+from typing import List
+
 
 # Simple retrieve-then-read implementation, using the Cognitive Search and OpenAI APIs directly. It first retrieves
 # top documents from search, then constructs a prompt with them, and then uses OpenAI to generate an completion 
@@ -48,7 +50,7 @@ Search query:
         self.sourcepage_field = sourcepage_field
         self.content_field = content_field
 
-    def run(self, history: list[dict], overrides: dict) -> any:
+    def run(self, history: List[dict], overrides: dict) -> any:
         use_semantic_captions = True if overrides.get("semantic_captions") else False
         top = overrides.get("top") or 3
         exclude_category = overrides.get("exclude_category") or None


### PR DESCRIPTION
## Purpose
This fixes the following error when running on Python 3.8.10 on Ubuntu 20.04.6 LTS:
```
Starting backend

Traceback (most recent call last):
  File "./app.py", line 12, in <module>
    from approaches.chatreadretrieveread import ChatReadRetrieveReadApproach
  File "./azure-search-openai-demo/app/backend/approaches/chatreadretrieveread.py", line 10, in <module>
    class ChatReadRetrieveReadApproach(Approach):
  File "./azure-search-openai-demo/app/backend/approaches/chatreadretrieveread.py", line 52, in ChatReadRetrieveReadApproach
    def run(self, history: list[dict], overrides: dict) -> any:
TypeError: 'type' object is not subscriptable
Failed to start backend
```

Closes #142.


## Does this introduce a breaking change?
[x] Yes
[ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

Updates the codebase to work with Python 3.8 type aliases for lists.

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
```
cd ./app
./start.sh
```

## What to Check
Verify that the following are valid
* Homepage loads

## Other Information
<!-- Add any other helpful information that may be needed here. -->