### PR TITLE
Add deployment parameters to re-use OpenAI Deployments

### DIFF
--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -29,6 +29,12 @@
     "formRecognizerSkuName": {
       "value": "S0"
     },
+    "chatGptDeploymentName": {
+      "value": "${AZURE_OPENAI_CHATGPT_DEPLOYMENT}"
+    },
+    "gptDeploymentName": {
+      "value": "${AZURE_OPENAI_GPT_DEPLOYMENT}"
+    },
     "searchServiceName": {
       "value": "${AZURE_SEARCH_SERVICE}"
     },


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
If you want to re-use an existing OpenAI deployment, and it has a different name from the default, the azd env variables have no effect on the deployment. This PR passes the azd env variables referenced in the README through the bicep deployment.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
Follow the README instructions for testing an existing OpenAI deployment, but with a different name from the default.

## What to Check
Verify that the following are valid
The deployment succeeds without failing and references your existing OpenAI deployment.

## Other Information
<!-- Add any other helpful information that may be needed here. -->