### PR TITLE
Add networkAcls prop in cognitiveservices.bicep

### DIFF
--- a/infra/core/ai/cognitiveservices.bicep
+++ b/infra/core/ai/cognitiveservices.bicep
@@ -18,6 +18,11 @@ resource account 'Microsoft.CognitiveServices/accounts@2022-10-01' = {
   properties: {
     customSubDomainName: customSubDomainName
     publicNetworkAccess: publicNetworkAccess
+    networkAcls: {
+      defaultAction: 'Allow'
+      virtualNetworkRules: []
+      ipRules: []
+    }
   }
   sku: sku
 }


### PR DESCRIPTION
## Purpose

I was in the scenario with an already deployed OpenAI service on my Azure subscription.

After run `azd up`, some steps were failing with this error:

```
{
  "code": "DeploymentFailed",
  "target": "/subscriptions/<sub-id>/resourceGroups/<my-rg>/providers/Microsoft.Resources/deployments/openai",
  "message": "At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.",
  "details": [
    {
      "code": "BadRequest",
      "message": "NetworkAcls is required for this resouce."
    }
  ]
}
```

Then I resolved adding a default value for NetworkAcls in core/ai/cognitiveservices.bicep


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->