### PR TITLE
FIX: Prompt override error in the Front end

### DIFF
--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -92,7 +92,7 @@ Search query:
         elif prompt_override.startswith(">>>"):
             prompt = self.prompt_prefix.format(injected_prompt=prompt_override[3:] + "\n", sources=content, chat_history=self.get_chat_history_as_text(history), follow_up_questions_prompt=follow_up_questions_prompt)
         else:
-            prompt = prompt_override.format(sources=content, chat_history=self.get_chat_history_as_text(history), follow_up_questions_prompt=follow_up_questions_prompt)
+            prompt = prompt_override.format(injected_prompt="", sources=content, chat_history=self.get_chat_history_as_text(history), follow_up_questions_prompt=follow_up_questions_prompt)
 
         # STEP 3: Generate a contextual and content specific answer using the search results and chat history
         completion = openai.Completion.create(


### PR DESCRIPTION
## Purpose
Currently, if you try to use the "Prompt Override" in Developer Tools, you will get a Python error coming back in the Chat response. This is because in `chatreadretrieveread.py` the `injected_prompt` is not being populated in the `prompt_override.format` call (as it is in the other cases of the `if` statement). In this case, `injected_prompt` is irrelevant, so I have set it to `""` as per the un-overriden case.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Open Developer Tools and enter something into the "Override prompt template".
* Ask a question.
* Response should return without an error.

## What to Check
* Response should return without an error.

## Other Information
n/a