### PR TITLE
Avoid setenv on blank lines

### DIFF
--- a/scripts/prepdocs.ps1
+++ b/scripts/prepdocs.ps1
@@ -5,6 +5,10 @@ Write-Host ""
 $output = azd env get-values
 
 foreach ($line in $output) {
+  if (!$line.Contains('=')) {
+    continue
+  }
+
   $name, $value = $line.Split("=")
   $value = $value -replace '^\"|\"$'
   [Environment]::SetEnvironmentVariable($name, $value)


### PR DESCRIPTION
Update prepdocs.ps1 to avoid `SetEnvironmentVariables` on blank lines. This makes it more inline with prepdocs.sh.

## Does this introduce a breaking change?
[ ] Yes
[x] No

## Pull Request Type
[x] Bugfix

Fixes #213
