### PR TITLE
Fix non-subscription owner scenarios by adding Search Service Contributor role

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -268,6 +268,16 @@ module searchContribRoleUser 'core/security/role.bicep' = {
   }
 }
 
+module searchSvcContribRoleUser 'core/security/role.bicep' = {
+  scope: searchServiceResourceGroup
+  name: 'search-svccontrib-role-user'
+  params: {
+    principalId: principalId
+    roleDefinitionId: '7ca78c08-252a-4471-8644-bb5ff32d4ba0'
+    principalType: 'User'
+  }
+}
+
 // SYSTEM IDENTITIES
 module openAiRoleBackend 'core/security/role.bicep' = {
   scope: openAiResourceGroup


### PR DESCRIPTION
## Purpose
Listing and creating search indexes requires that the user has either Owner or Search Service Contributor RBAC roles. For cases where the user is not subscription owner, this change makes things work by adding the Search Service Contributor role for the user running "azd up".

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```
## Pull Request Type
What kind of change does this Pull Request introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
