### PR TITLE
Update prepdocs.sh to use python3

### DIFF
--- a/app/start.sh
+++ b/app/start.sh
@@ -17,7 +17,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo 'Creating python virtual environment "backend/backend_env"'
-python -m venv backend/backend_env
+python3 -m venv backend/backend_env
 
 echo ""
 echo "Restoring backend python packages"

--- a/scripts/prepdocs.sh
+++ b/scripts/prepdocs.sh
@@ -12,7 +12,7 @@ $(azd env get-values)
 EOF
 
 echo 'Creating python virtual environment "scripts/.venv"'
-python -m venv scripts/.venv
+python3 -m venv scripts/.venv
 
 echo 'Installing dependencies from "requirements.txt" into virtual environment'
 ./scripts/.venv/bin/python -m pip install -r scripts/requirements.txt


### PR DESCRIPTION
## Purpose

It's generally safer to use `python3` than `python` since the latter is an alias (and does not work on my Mac). `python3` should exist, however, if Python 3 is involved.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Run `azd up` on Mac
* Don't see error about python: command not found