### PR TITLE
Suggested LangChain version has known security vulnerability

### DIFF
--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -1,6 +1,6 @@
 azure-identity==1.13.0b3
 Flask==2.2.2
-langchain==0.0.78
+langchain==0.0.132
 openai==0.26.4
 azure-search-documents==11.4.0b3
 azure-storage-blob==12.14.1


### PR DESCRIPTION
Dear All, original repo set requirements for langchain library to 0.0.78. Unfortunately, it's vulnerable to prompt injection attacks as can be verified through this reference in NIST vulnerabilities database: https://nvd.nist.gov/vuln/detail/CVE-2023-29374. It was patched only from v0.0.132, so suggested it as a minimum.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* There is known security vulnerability in suggested version of the library.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Security
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* https://nvd.nist.gov/vuln/detail/CVE-2023-29374

## Other Information
<!-- Add any other helpful information that may be needed here. -->