### PR TITLE
Change content_file to use flask.send_file instead

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -4,7 +4,7 @@ import mimetypes
 import time
 import logging
 import openai
-from flask import Flask, request, jsonify, send_file
+from flask import Flask, request, jsonify, send_file, abort
 from azure.identity import DefaultAzureCredential
 from azure.search.documents import SearchClient
 from approaches.retrievethenread import RetrieveThenReadApproach
@@ -77,6 +77,8 @@ def static_file(path):
 @app.route("/content/<path>")
 def content_file(path):
     blob = blob_container.get_blob_client(path).download_blob()
+    if not blob.properties or "content_settings" not in blob.properties:
+        abort(404)
     mime_type = blob.properties["content_settings"]["content_type"]
     if mime_type == "application/octet-stream":
         mime_type = mimetypes.guess_type(path)[0] or "application/octet-stream"

--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -66,8 +66,6 @@ chat_approaches = {
 
 app = Flask(__name__)
 
-logging.basicConfig(level=logging.DEBUG)
-
 @app.route("/", defaults={"path": "index.html"})
 @app.route("/<path:path>")
 def static_file(path):


### PR DESCRIPTION
## Purpose

Fixes #277 
Currently, if you upload a file to blob storage that has a non-ascii character, it will fail once app service tries to return it in a response. This appears to be due to the setting of filename in Content-Disposition header to a string that contains non-ascii characters.

Fortunately, flask already has send_file which takes care of that issue:
https://flask.palletsprojects.com/en/2.3.x/api/#flask.send_file

See implementation here:
https://github.com/pallets/flask/blob/fae889d467a0a19385978f7e979234771a0eb10d/src/werkzeug/utils.py#L463

So I modified the content_file function to use send_file instead, with an io.BytesIO object built from the blob content. I deployed to App Service and it does seem to fix it.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Upload a file to Blob that has "ä" in the filename.
* Ask ChatGPT a question that is answered by that file
* Click filename, see it successfully load. *On production, App Service
