### PR TITLE
[docs] Clarify that azd init already clones the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ You can run this repo virtually by using GitHub Codespaces or VS Code Remote Con
 1. Run `azd auth login`
 1. Run `azd init -t azure-search-openai-demo`
     * For the target location, the regions that currently support the models used in this sample are **East US** or **South Central US**. For an up-to-date list of regions and models, check [here](https://learn.microsoft.com/en-us/azure/cognitive-services/openai/concepts/models)
+    * note that this command will initialize a git repository and you do not need to clone this repository
 
 #### Starting from scratch:
 


### PR DESCRIPTION
clarify that azd init also initializes a git repo and you do should not in fact clone the repo.

I am used when I start working on a project in github to just clone the repo, but the suggested way to initialized this project in the documentation is the command `azd init`. It was not clear to me before running it that this command already initializes a git repo, maybe this is useful for others.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## Other Information
<!-- Add any other helpful information that may be needed here. -->