### PR TITLE
Allow usage of existing OpenAI model deployments

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -37,10 +37,10 @@ param formRecognizerResourceGroupLocation string = location
 
 param formRecognizerSkuName string = 'S0'
 
-param gptDeploymentName string = 'davinci'
+param gptDeploymentName string = ''
 param gptDeploymentCapacity int = 30
 param gptModelName string = 'text-davinci-003'
-param chatGptDeploymentName string = 'chat'
+param chatGptDeploymentName string = ''
 param chatGptDeploymentCapacity int = 30
 param chatGptModelName string = 'gpt-35-turbo'
 
@@ -50,6 +50,8 @@ param principalId string = ''
 var abbrs = loadJsonContent('abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
 var tags = { 'azd-env-name': environmentName }
+var gptDeployment = empty(gptDeploymentName) ? 'davinci' : gptDeploymentName
+var chatGptDeployment = empty(chatGptDeploymentName) ? 'chat' : chatGptDeploymentName
 
 // Organize resources in a resource group
 resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
@@ -109,8 +111,8 @@ module backend 'core/host/appservice.bicep' = {
       AZURE_OPENAI_SERVICE: openAi.outputs.name
       AZURE_SEARCH_INDEX: searchIndexName
       AZURE_SEARCH_SERVICE: searchService.outputs.name
-      AZURE_OPENAI_GPT_DEPLOYMENT: gptDeploymentName
-      AZURE_OPENAI_CHATGPT_DEPLOYMENT: chatGptDeploymentName
+      AZURE_OPENAI_GPT_DEPLOYMENT: gptDeployment
+      AZURE_OPENAI_CHATGPT_DEPLOYMENT: chatGptDeployment
     }
   }
 }
@@ -127,7 +129,7 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
     }
     deployments: [
       {
-        name: gptDeploymentName
+        name: gptDeployment
         model: {
           format: 'OpenAI'
           name: gptModelName
@@ -136,7 +138,7 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
         capacity: gptDeploymentCapacity
       }
       {
-        name: chatGptDeploymentName
+        name: chatGptDeployment
         model: {
           format: 'OpenAI'
           name: chatGptModelName
@@ -313,8 +315,8 @@ output AZURE_RESOURCE_GROUP string = resourceGroup.name
 
 output AZURE_OPENAI_SERVICE string = openAi.outputs.name
 output AZURE_OPENAI_RESOURCE_GROUP string = openAiResourceGroup.name
-output AZURE_OPENAI_GPT_DEPLOYMENT string = gptDeploymentName
-output AZURE_OPENAI_CHATGPT_DEPLOYMENT string = chatGptDeploymentName
+output AZURE_OPENAI_GPT_DEPLOYMENT string = gptDeployment
+output AZURE_OPENAI_CHATGPT_DEPLOYMENT string = chatGptDeployment
 
 output AZURE_FORMRECOGNIZER_SERVICE string = formRecognizer.outputs.name
 output AZURE_FORMRECOGNIZER_RESOURCE_GROUP string = formRecognizerResourceGroup.name

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -43,6 +43,12 @@
     },
     "storageResourceGroupName": {
       "value": "${AZURE_STORAGE_RESOURCE_GROUP}"
+    },
+    "chatGptDeploymentName": {
+      "value": "${AZURE_OPENAI_CHATGPT_DEPLOYMENT}"
+    },
+    "gptDeploymentName": {
+      "value": "${AZURE_OPENAI_GPT_DEPLOYMENT}"
     }
   }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Allow usage of existing ChatGPT and GPT deployments not using the names 'davinci' or 'chat'

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

1. Set AZURE_OPENAI_CHATGPT_DEPLOYMENT to another value besides 'chat'
2. Set AZURE_OPENAI_GPT_DEPLOYMENT to another value besides 'davinci'

Deploy and validate the deployment succeeds

1. Set AZURE_OPENAI_CHATGPT_DEPLOYMENT to an empty string
2. Set AZURE_OPENAI_GPT_DEPLOYMENT to an empty string

Deploy and validate the deployment succeeds

## What to Check
Verify that the following are valid
If these environment variables are set to another deployment besides 'davinci' and 'chat', validate the sample app still works.
If these environment variables are empty, validate the deployment succeeds without any validation errors around cognitive services account segment lengths

## Other Information
<!-- Add any other helpful information that may be needed here. -->