### PR TITLE
Use Python 3.10 base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-ARG VARIANT=bullseye
-FROM --platform=amd64 mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+ARG IMAGE=bullseye
+FROM --platform=amd64 mcr.microsoft.com/devcontainers/${IMAGE}
 RUN export DEBIAN_FRONTEND=noninteractive \
      && apt-get update && apt-get install -y xdg-utils \
      && apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,13 +3,10 @@
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
-            "VARIANT": "bullseye"
+            "IMAGE": "python:3.10"
         }
     },
     "features": {
-        "ghcr.io/devcontainers/features/python:1": {
-            "version": "os-provided"
-        },
         "ghcr.io/devcontainers/features/node:1": {
             "version": "16",
             "nodeGypDependencies": false


### PR DESCRIPTION
## Purpose

This PR updates the dev container to use a Python 3.10 base image, instead of the universal bullseye. It subsequently removes the Python feature, since it's slow. The feature was also using "os-provided" as the Python version, which is problematic on machines that have bad Python installs (like mine!). It's a more consistent environment to use the Docker's Python.
(Related issue: #343)

A similar change was made in the Python azd templates a while back:
https://github.com/Azure-Samples/todo-python-mongo-terraform/blob/main/.devcontainer/Dockerfile

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Open in Dev Container on Mac, run azd up
*  Open in GitHub Codespaces, run azd up.
