### PR TITLE
Use has_key instead of in operator

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -77,7 +77,7 @@ def static_file(path):
 @app.route("/content/<path>")
 def content_file(path):
     blob = blob_container.get_blob_client(path).download_blob()
-    if not blob.properties or "content_settings" not in blob.properties:
+    if not blob.properties or not blob.properties.has_key("content_settings"):
         abort(404)
     mime_type = blob.properties["content_settings"]["content_type"]
     if mime_type == "application/octet-stream":


### PR DESCRIPTION
## Purpose

Unfortunately, the Python SDK DictMixin doesn't support the "in" operator. I've sent a PR to fix it: https://github.com/Azure/azure-sdk-for-python/pull/30846
This PR updates the code to use has_key() instead, which is defined for the DictMixin and thus the Blob. That method is considered deprecated for proper python dicts, so it'd be nice to use "in" in the future.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Run ./start.sh
* Click on a citation