### PR TITLE
Change davinci to gpt35-turbo

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -39,7 +39,7 @@ param formRecognizerSkuName string = 'S0'
 
 param gptDeploymentName string // Set in main.parameters.json
 param gptDeploymentCapacity int = 30
-param gptModelName string = 'text-davinci-003'
+param gptModelName string = 'gpt-35-turbo'
 param chatGptDeploymentName string // Set in main.parameters.json
 param chatGptDeploymentCapacity int = 30
 param chatGptModelName string = 'gpt-35-turbo'
@@ -131,7 +131,7 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
         model: {
           format: 'OpenAI'
           name: gptModelName
-          version: '1'
+          version: '0301'
         }
         sku: {
           name: 'Standard'


### PR DESCRIPTION
## Purpose

Today, Azure disabled new deployments of text-davinci-003, so deployments will fail with an error:

"DeploymentModelNotSupported: Creating account deployment is not supported by the model 'text-davinci-003'. This is usually because there are better models available for the similar functionality."

This change does the minimal change to get deploys to work, swapping text-davinci-003 with gpt-35-turbo. Unfortunately, it really does not do that well on generating search queries, at least with our current prompt, so the chat interface isn't working well. Perhaps we should default to the "Chat" tab until it's worked out.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[X] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Get the code
* Run azd env new, azd up
* See it deploy successfully
