### PR TITLE
Use location picker for openAI

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -27,7 +27,14 @@ param storageContainerName string = 'content'
 
 param openAiServiceName string = ''
 param openAiResourceGroupName string = ''
-param openAiResourceGroupLocation string = location
+@description('Location for the OpenAI resource group')
+@allowed(['eastus', 'francecentral', 'southcentralus', 'uksouth', 'westeurope'])
+@metadata({
+  azd: {
+    type: 'location'
+  }
+})
+param openAiResourceGroupLocation string
 
 param openAiSkuName string = 'S0'
 


### PR DESCRIPTION
## Purpose

This PR uses the location picker functionality for *just* the Open AI resource group location.
That allows us to constrain the locations to just the supported ones, so that folks dont find out after a long deploy about a bad location selection.
This also makes it easy for folks to pick a different location for OpenAI than their main location, which came up in a recent issue.

Here's what the picker looks like - it comes up after packaging but before provision:

![Screenshot 2023-07-06 at 4 56 00 PM](https://github.com/Azure-Samples/azure-search-openai-demo/assets/297042/62c13390-e621-457e-bd23-45076a78a930)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Run azd up