### PR TITLE
Frontend basic code splitting

### DIFF
--- a/app/frontend/src/index.tsx
+++ b/app/frontend/src/index.tsx
@@ -1,33 +1,38 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { HashRouter, Routes, Route } from "react-router-dom";
+import { createHashRouter, RouterProvider } from "react-router-dom";
 import { initializeIcons } from "@fluentui/react";
 
 import "./index.css";
 
 import Layout from "./pages/layout/Layout";
-import NoPage from "./pages/NoPage";
-import OneShot from "./pages/oneshot/OneShot";
 import Chat from "./pages/chat/Chat";
 
 initializeIcons();
 
-export default function App() {
-    return (
-        <HashRouter>
-            <Routes>
-                <Route path="/" element={<Layout />}>
-                    <Route index element={<Chat />} />
-                    <Route path="qa" element={<OneShot />} />
-                    <Route path="*" element={<NoPage />} />
-                </Route>
-            </Routes>
-        </HashRouter>
-    );
-}
+const router = createHashRouter([
+    {
+        path: "/",
+        element: <Layout />,
+        children: [
+            {
+                index: true,
+                element: <Chat />
+            },
+            {
+                path: "qa",
+                lazy: () => import("./pages/oneshot/OneShot")
+            },
+            {
+                path: "*",
+                lazy: () => import("./pages/NoPage")
+            }
+        ]
+    }
+]);
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <React.StrictMode>
-        <App />
+        <RouterProvider router={router} />
     </React.StrictMode>
 );

--- a/app/frontend/src/pages/NoPage.tsx
+++ b/app/frontend/src/pages/NoPage.tsx
@@ -1,5 +1,5 @@
-const NoPage = () => {
+export function Component(): JSX.Element {
     return <h1>404</h1>;
-};
+}
 
-export default NoPage;
+Component.displayName = "NoPage";

--- a/app/frontend/src/pages/oneshot/OneShot.tsx
+++ b/app/frontend/src/pages/oneshot/OneShot.tsx
@@ -10,7 +10,7 @@ import { ExampleList } from "../../components/Example";
 import { AnalysisPanel, AnalysisPanelTabs } from "../../components/AnalysisPanel";
 import { SettingsButton } from "../../components/SettingsButton/SettingsButton";
 
-const OneShot = () => {
+export function Component(): JSX.Element {
     const [isConfigPanelOpen, setIsConfigPanelOpen] = useState(false);
     const [approach, setApproach] = useState<Approaches>(Approaches.RetrieveThenRead);
     const [promptTemplate, setPromptTemplate] = useState<string>("");
@@ -246,6 +246,6 @@ const OneShot = () => {
             </Panel>
         </div>
     );
-};
+}
 
-export default OneShot;
+Component.displayName = "OneShot";

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -7,7 +7,20 @@ export default defineConfig({
     build: {
         outDir: "../backend/static",
         emptyOutDir: true,
-        sourcemap: true
+        sourcemap: true,
+        rollupOptions: {
+            output: {
+                manualChunks: id => {
+                    if (id.includes("@fluentui/react-icons")) {
+                        return "fluentui-icons";
+                    } else if (id.includes("@fluentui/react")) {
+                        return "fluentui-react";
+                    } else if (id.includes("node_modules")) {
+                        return "vendor";
+                    }
+                }
+            }
+        }
     },
     server: {
         proxy: {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This PR introduces basic code splitting in the frontend:
  * Updated react-router-dom hash router to 6.4 API
  * Lazy routing to 'q&a' and 'not found' pages. 
    * 'Layout' and 'Chat' aren't lazy loaded because that's our initial page.
  * Configured rollup manual chunking in vite. _This also gets rid of the 'chunks over 500kb' vite warning_.
    * @fluentui/react-icons goes to its own chunk ('fluentui-icons')
    * @fluentui/react goes to its own chunk ('fluentui-react')
    * Other node_modules dependencies go to a 'vendor' chunk

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
cd app
start.ps1 or start.sh
```

## What to Check
Verify that the following are valid
* All frontend pages load as expected.