### PR TITLE
Tell Oryx to configure gunicorn workers dynamically

### DIFF
--- a/infra/core/host/appservice.bicep
+++ b/infra/core/host/appservice.bicep
@@ -70,6 +70,7 @@ resource appService 'Microsoft.Web/sites@2022-03-01' = {
         SCM_DO_BUILD_DURING_DEPLOYMENT: string(scmDoBuildDuringDeployment)
         ENABLE_ORYX_BUILD: string(enableOryxBuild)
       },
+      runtimeName == 'python' ? { PYTHON_ENABLE_GUNICORN_MULTIWORKERS: 'true'} : {},
       !empty(applicationInsightsName) ? { APPLICATIONINSIGHTS_CONNECTION_STRING: applicationInsights.properties.ConnectionString } : {},
       !empty(keyVaultName) ? { AZURE_KEY_VAULT_ENDPOINT: keyVault.properties.vaultUri } : {})
   }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -46,7 +46,7 @@ param formRecognizerSkuName string = 'S0'
 
 param gptDeploymentName string // Set in main.parameters.json
 param gptDeploymentCapacity int = 30
-param gptModelName string = 'text-davinci-003'
+param gptModelName string = 'gpt-35-turbo'
 param chatGptDeploymentName string // Set in main.parameters.json
 param chatGptDeploymentCapacity int = 30
 param chatGptModelName string = 'gpt-35-turbo'
@@ -143,7 +143,7 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
         model: {
           format: 'OpenAI'
           name: gptModelName
-          version: '1'
+          version: '0301'
         }
         sku: {
           name: 'Standard'

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -122,7 +122,6 @@ module backend 'core/host/appservice.bicep' = {
       AZURE_OPENAI_GPT_DEPLOYMENT: gptDeploymentName
       AZURE_OPENAI_CHATGPT_DEPLOYMENT: chatGptDeploymentName
       AZURE_OPENAI_EMB_DEPLOYMENT: embeddingDeploymentName
-      PYTHON_ENABLE_GUNICORN_MULTIWORKERS: 'true'
     }
   }
 }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -46,7 +46,7 @@ param formRecognizerSkuName string = 'S0'
 
 param gptDeploymentName string // Set in main.parameters.json
 param gptDeploymentCapacity int = 30
-param gptModelName string = 'gpt-35-turbo'
+param gptModelName string = 'text-davinci-003'
 param chatGptDeploymentName string // Set in main.parameters.json
 param chatGptDeploymentCapacity int = 30
 param chatGptModelName string = 'gpt-35-turbo'
@@ -122,6 +122,7 @@ module backend 'core/host/appservice.bicep' = {
       AZURE_OPENAI_GPT_DEPLOYMENT: gptDeploymentName
       AZURE_OPENAI_CHATGPT_DEPLOYMENT: chatGptDeploymentName
       AZURE_OPENAI_EMB_DEPLOYMENT: embeddingDeploymentName
+      PYTHON_ENABLE_GUNICORN_MULTIWORKERS: 'true'
     }
   }
 }
@@ -142,7 +143,7 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
         model: {
           format: 'OpenAI'
           name: gptModelName
-          version: '0301'
+          version: '1'
         }
         sku: {
           name: 'Standard'


### PR DESCRIPTION
## Purpose

This PR enables PYTHON_ENABLE_GUNICORN_MULTIWORKERS on App Service. When Oryx sees that, it will auto configure gunicorn to use a worker count based off the formula of CPU_COUNT * 2 + 1. This should hopefully resolve issues like #272.

Here's Oryx docs about the config option:
https://github.com/microsoft/Oryx/blob/5239b0416cdddcf5bf0aef6703eb339efa865d67/doc/runtimes/python.md?plain=1#L101

The other approach is for us to specify our own startup script that does the same thing (as I describe in https://github.com/Azure-Samples/azure-search-openai-demo/issues/272#issuecomment-1589303445), but for now, this is the quickest fix.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* azd up
* Check Advanced Tools > Download as zip > default_docker.log, see that it spawned 3 workers
* Also SSH into App Service and check out /opt/startup/startup.sh, you'll see workers=3 in the command.

