### PR TITLE
Respect ENV values for resource group and index name

### DIFF
--- a/infra/abbreviations.json
+++ b/infra/abbreviations.json
@@ -131,6 +131,5 @@
   "webSitesAppService": "app-",
   "webSitesAppServiceEnvironment": "ase-",
   "webSitesFunctions": "func-",
-  "webStaticSites": "stapp-",
-  "searchIndexName":"gptkbindex"
+  "webStaticSites": "stapp-"
 }

--- a/infra/abbreviations.json
+++ b/infra/abbreviations.json
@@ -131,5 +131,6 @@
   "webSitesAppService": "app-",
   "webSitesAppServiceEnvironment": "ase-",
   "webSitesFunctions": "func-",
-  "webStaticSites": "stapp-"
+  "webStaticSites": "stapp-",
+  "searchIndexName":"gptkbindex"
 }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -18,7 +18,7 @@ param searchServiceResourceGroupName string = ''
 param searchServiceResourceGroupLocation string = location
 
 param searchServiceSkuName string = 'standard'
-param searchIndexName string = 'gptkbindex'
+param searchIndexName string = ''
 
 param storageAccountName string = ''
 param storageResourceGroupName string = ''
@@ -117,7 +117,7 @@ module backend 'core/host/appservice.bicep' = {
       AZURE_STORAGE_ACCOUNT: storage.outputs.name
       AZURE_STORAGE_CONTAINER: storageContainerName
       AZURE_OPENAI_SERVICE: openAi.outputs.name
-      AZURE_SEARCH_INDEX: searchIndexName
+      AZURE_SEARCH_INDEX: !empty(searchIndexName) ? searchIndexName : '${abbrs.searchIndexName}'
       AZURE_SEARCH_SERVICE: searchService.outputs.name
       AZURE_OPENAI_GPT_DEPLOYMENT: gptDeploymentName
       AZURE_OPENAI_CHATGPT_DEPLOYMENT: chatGptDeploymentName

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -117,7 +117,7 @@ module backend 'core/host/appservice.bicep' = {
       AZURE_STORAGE_ACCOUNT: storage.outputs.name
       AZURE_STORAGE_CONTAINER: storageContainerName
       AZURE_OPENAI_SERVICE: openAi.outputs.name
-      AZURE_SEARCH_INDEX: !empty(searchIndexName) ? searchIndexName : '${abbrs.searchIndexName}'
+      AZURE_SEARCH_INDEX: searchIndexName
       AZURE_SEARCH_SERVICE: searchService.outputs.name
       AZURE_OPENAI_GPT_DEPLOYMENT: gptDeploymentName
       AZURE_OPENAI_CHATGPT_DEPLOYMENT: chatGptDeploymentName

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -18,7 +18,7 @@ param searchServiceResourceGroupName string = ''
 param searchServiceResourceGroupLocation string = location
 
 param searchServiceSkuName string = 'standard'
-param searchIndexName string = ''
+param searchIndexName string // Set in main.parameters.json
 
 param storageAccountName string = ''
 param storageResourceGroupName string = ''

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -33,7 +33,7 @@
       "value": "S0"
     },
     "searchIndexName": {
-      "value": "${AZURE_SEARCH_INDEX}"
+      "value": "${AZURE_SEARCH_INDEX=gptkbindex}"
     },
     "searchServiceName": {
       "value": "${AZURE_SEARCH_SERVICE}"

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -5,6 +5,9 @@
     "environmentName": {
       "value": "${AZURE_ENV_NAME}"
     },
+    "resourceGroupName": {
+      "value": "${AZURE_RESOURCE_GROUP}"
+    },
     "location": {
       "value": "${AZURE_LOCATION}"
     },
@@ -28,6 +31,9 @@
     },
     "formRecognizerSkuName": {
       "value": "S0"
+    },
+    "searchIndexName": {
+      "value": "${AZURE_SEARCH_INDEX}"
     },
     "searchServiceName": {
       "value": "${AZURE_SEARCH_SERVICE}"


### PR DESCRIPTION
## Purpose
This allows the bicep to respect the values ( AZURE_RESOURCE_GROUP & AZURE_SEARCH_SERVICE) manually entered in the .azure/.env file should they be required.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
1. Run `azd up` on a new environment
1. Update the values AZURE_RESOURCE_GROUP and AZURE_SEARCH_SERVICE in the `.azure/.env` file. 
```
```

## What to Check
Verify that the following are valid.
* Verify that the full product was created appropriately after the first step
* Verify the resource group and new webapp were created appropriately. Verify the new index with the new name was created. 
* Verify a search index was created with the name entered in the value was respected

## Other Information
<!-- Add any other helpful information that may be needed here. -->