### PR TITLE
Change to port 50505

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,7 @@
         }
     },
     "forwardPorts": [
-        5000
+        50505
     ],
     "postCreateCommand": "",
     "remoteUser": "vscode",

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ either you or they can follow these steps:
 ### Quickstart
 
 * In Azure: navigate to the Azure WebApp deployed by azd. The URL is printed out when azd completes (as "Endpoint"), or you can find it in the Azure portal.
-* Running locally: navigate to 127.0.0.1:5000
+* Running locally: navigate to 127.0.0.1:50505
 
 Once in the web app:
 

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -24,8 +24,8 @@ export default defineConfig({
     },
     server: {
         proxy: {
-            "/ask": "http://localhost:5000",
-            "/chat": "http://localhost:5000"
+            "/ask": "http://localhost:50505",
+            "/chat": "http://localhost:50505"
         }
     }
 });

--- a/app/start.ps1
+++ b/app/start.ps1
@@ -64,9 +64,8 @@ Write-Host ""
 Write-Host "Starting backend"
 Write-Host ""
 Set-Location ../backend
-Start-Process http://127.0.0.1:5000
 
-Start-Process -FilePath $venvPythonPath -ArgumentList "-m quart --app main:app run --port 5000 --reload" -Wait -NoNewWindow
+Start-Process -FilePath $venvPythonPath -ArgumentList "-m quart --app main:app run --port 50505 --reload" -Wait -NoNewWindow
 
 if ($LASTEXITCODE -ne 0) {
     Write-Host "Failed to start backend"

--- a/app/start.sh
+++ b/app/start.sh
@@ -56,8 +56,7 @@ echo "Starting backend"
 echo ""
 
 cd ../backend
-xdg-open http://127.0.0.1:5000
-./backend_env/bin/python -m quart --app main:app run --port 5000 --reload
+./backend_env/bin/python -m quart --app main:app run --port 50505 --reload
 if [ $? -ne 0 ]; then
     echo "Failed to start backend"
     exit $?


### PR DESCRIPTION
## Purpose

Port 5000 doesn't work well on many Macs due to a system process that uses 5000. You don't even get a port conflict error, it just silently fails to load :( I would love to not have to constantly change start.sh when I work on this repo, so I propose my favorite port, 50505.

This PR also removes the command the opens the browser. That command opens the browser before the app starts up, so you end up having to reload it anyway, and you have a moment of thinking it's broken. I think it's better to just click on the URL and open it once it's running.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* cd app
* ./start.sh
* Click on URL in terminal
* See local app