### PR TITLE
Gunicorn timeout

### DIFF
--- a/app/backend/gunicorn.conf.py
+++ b/app/backend/gunicorn.conf.py
@@ -5,7 +5,9 @@ max_requests_jitter = 50
 log_file = "-"
 bind = "0.0.0.0"
 
-timeout = 600
+timeout = 220
+# https://learn.microsoft.com/en-us/troubleshoot/azure/app-service/web-apps-performance-faqs#why-does-my-request-time-out-after-230-seconds
+
 num_cpus = multiprocessing.cpu_count()
 workers = (num_cpus * 2) + 1
 worker_class = "uvicorn.workers.UvicornWorker"

--- a/app/backend/gunicorn.conf.py
+++ b/app/backend/gunicorn.conf.py
@@ -5,7 +5,7 @@ max_requests_jitter = 50
 log_file = "-"
 bind = "0.0.0.0"
 
-timeout = 220
+timeout = 230
 # https://learn.microsoft.com/en-us/troubleshoot/azure/app-service/web-apps-performance-faqs#why-does-my-request-time-out-after-230-seconds
 
 num_cpus = multiprocessing.cpu_count()


### PR DESCRIPTION
## Purpose

This PR updates gunicorn.conf.py to have a timeout of 230, the same as the App Service global timeout (due to load balancers: https://learn.microsoft.com/en-us/troubleshoot/azure/app-service/web-apps-performance-faqs#why-does-my-request-time-out-after-230-seconds).

I don't think this improves performance, but at least it is less misleading to see 600 and think that's how long you'll get. 

timeout docs here: 
https://docs.gunicorn.org/en/stable/settings.html?highlight=timeout#timeout


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Deploy, app should run