### PR TITLE
Use `Standard_LRS` instead of `Standard_ZRS`

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -220,7 +220,7 @@ module storage 'core/storage/storage-account.bicep' = {
     tags: tags
     publicNetworkAccess: 'Enabled'
     sku: {
-      name: 'Standard_ZRS'
+      name: 'Standard_LRS'
     }
     deleteRetentionPolicy: {
       enabled: true


### PR DESCRIPTION
## Purpose
I was trying to deploy the sample, but it was difficult to find an Azure region that would support `text-embedding-ada-002`, and had available OpenAI quota in my subscription, and supported the `Standard_ZRS` storage type. Although ZRS is probably important for production scenarios, using zone redundant storage seems unnecessary for getting started with the sample and unnecessarily limits the user's region options.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce? Change storage type used when deploying via `azd up` from `Standard_ZRS` to `Standard_LRS`.

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

```
azd env new [your-new-name]
azd up     (Target the `northcentralus` region which appears to not support `Standard_ZRS`)
```

## Other Information
@pamelafox suggested that using `Standard_ZRS` for production could be covered in a new FAQ/readme section on productionizing the sample.