### PR TITLE
Add support for Palm, Claude-2, Llama2, CodeLlama (100+LLMs) + A/B Testing in Prod

### DIFF
--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import openai
+from litellm import acompletion
 from azure.search.documents.aio import SearchClient
 from azure.search.documents.models import QueryType
 
@@ -77,7 +78,7 @@ If you cannot generate a search query, return just the number 0.
             self.chatgpt_token_limit - len(user_q)
             )
 
-        chat_completion = await openai.ChatCompletion.acreate(
+        chat_completion = await acompletion(
             deployment_id=self.chatgpt_deployment,
             model=self.chatgpt_model,
             messages=messages,
@@ -147,7 +148,7 @@ If you cannot generate a search query, return just the number 0.
             history[-1]["user"]+ "\n\nSources:\n" + content, # Model does not handle lengthy system messages well. Moving sources to latest user conversation to solve follow up questions prompt.
             max_tokens=self.chatgpt_token_limit)
 
-        chat_completion = await openai.ChatCompletion.acreate(
+        chat_completion = await acompletion(
             deployment_id=self.chatgpt_deployment,
             model=self.chatgpt_model,
             messages=messages,

--- a/app/backend/approaches/retrievethenread.py
+++ b/app/backend/approaches/retrievethenread.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import openai
+from litellm import acompletion
 from azure.search.documents.aio import SearchClient
 from azure.search.documents.models import QueryType
 
@@ -98,7 +99,7 @@ info4.pdf: In-network institutions include Overlake, Swedish and others in the r
         message_builder.append_message('user', self.question)
 
         messages = message_builder.messages
-        chat_completion = await openai.ChatCompletion.acreate(
+        chat_completion = await acompletion(
             deployment_id=self.openai_deployment,
             model=self.chatgpt_model,
             messages=messages,


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM allows you to use any LLM as a drop in replacement for `gpt-3.5-turbo` 

In addition LiteLLM client allows you to:
* A/B test LLMs in production 
* Dynamically control each LLMs prompt, temperature, top_k etc in our UI (no need to re-deploy code)
* Logging to view input/outputs for each LLM

Here's a link to a live demo of litellm client: https://admin.litellm.ai/ 

![liteLLM-Ab-testing](https://github.com/ConvLab/ConvLab-3/assets/29436595/4206cb62-4c83-4ea1-9be2-e5a7dd306048)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ *] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ *] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->