### PR TITLE
Only validate bicep on changes to infra folder

### DIFF
--- a/.github/workflows/azure-dev-validation.yaml
+++ b/.github/workflows/azure-dev-validation.yaml
@@ -2,8 +2,12 @@ name: Validate AZD template
 on:
   push:
     branches: [ main ]
+    paths:
+      - "infra/**"
   pull_request:
     branches: [ main ]
+    paths:
+      - "infra/**"
 
 jobs:
   build:


### PR DESCRIPTION
Reduces the scope of the GitHub action for checking bicep to run if someone has changed anything in the infra folder.

Will make CI faster for everyone