### PR TITLE
Use absolute redirect uris for login and fetching tokens

### DIFF
--- a/app/frontend/src/authConfig.ts
+++ b/app/frontend/src/authConfig.ts
@@ -67,12 +67,17 @@ export const loginRequest = authSetup.loginRequest;
 
 const tokenRequest = authSetup.tokenRequest;
 
+// Build an absolute redirect URI using the current window's location and the relative redirect URI from auth setup
+export const getRedirectUri = () => {
+    return window.location.origin + authSetup.msalConfig.auth.redirectUri
+}
+
 // Get an access token for use with the API server.
 // ID token received when logging in may not be used for this purpose because it has the incorrect audience
 export const getToken = (client: IPublicClientApplication): Promise<AuthenticationResult | undefined> => {
     return client.acquireTokenSilent({
         ...tokenRequest,
-        redirectUri: authSetup.msalConfig.auth.redirectUri
+        redirectUri: getRedirectUri()
     })
     .catch((error) => {
         console.log(error);

--- a/app/frontend/src/components/LoginButton/LoginButton.tsx
+++ b/app/frontend/src/components/LoginButton/LoginButton.tsx
@@ -2,7 +2,7 @@ import { DefaultButton } from '@fluentui/react';
 import { useMsal } from '@azure/msal-react';
 
 import styles from "./LoginButton.module.css";
-import { loginRequest } from '../../authConfig';
+import { getRedirectUri, loginRequest } from '../../authConfig';
 
 
 export const LoginButton = () => {
@@ -17,7 +17,7 @@ export const LoginButton = () => {
       instance
           .loginPopup({
               ...loginRequest,
-              redirectUri: '/redirect',
+              redirectUri: getRedirectUri(),
           })
           .catch((error) => console.log(error));
   };


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

* Relative redirect URIs were being passed to token fetching methods. This resulted in the following error:
```
{ "error": "invalid_client", "error_description": "AADSTS500116: The reply uri specified in the request is not a valid URL. Allowed schemes: '*'.\r\nTrace ID: 30ef56ba-316c-46fe-bb75-8767e39a4a00\r\nCorrelation ID: d53vsvr51-30f8-4cf6-bf1e-83e55a6s4db5c5\r\nTimestamp: 2023-10-12 04:28:06Z", "error_codes": [ 500116 ], "timestamp": "2023-10-12 04:28:06Z", "trace_id": "30ef56ba-316c-46fe-bb75-8767e39a4a00", "correlation_id": "d53vsvr51-30f8-4cf6-bf1e-83e55a6s4db5c5" }
```

* Use absolute redirect URIs that include the scheme to resolve this issue

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Follow login setup instructions
* Checking oid or groups filter boxes in developer settings should not result in the token error in the networking developer tools tab.



