### PR TITLE
Add arguments required for OpenAI connection

### DIFF
--- a/scripts/prepdocs.ps1
+++ b/scripts/prepdocs.ps1
@@ -33,6 +33,5 @@ $argumentList = "./scripts/prepdocs.py `"$cwd/data/*`" $adlsGen2StorageAccountAr
 "--openaiservice `"$env:AZURE_OPENAI_SERVICE`" --openaikey `"$env:OPENAI_API_KEY`" " + `
 "--openaiorg `"$env:OPENAI_ORGANIZATION`" --openaideployment `"$env:AZURE_OPENAI_EMB_DEPLOYMENT`" " + `
 "--openaimodelname `"$env:AZURE_OPENAI_EMB_MODEL_NAME`" --index $env:AZURE_SEARCH_INDEX " + `
-"--formrecognizerservice $env:AZURE_FORMRECOGNIZER_SERVICE --tenantid $env:AZURE_TENANT_ID" + `
-"--openaihost $env:OPENAI_HOST --openaikey $env:OPENAI_API_KEY -v"
+"--formrecognizerservice $env:AZURE_FORMRECOGNIZER_SERVICE --tenantid $env:AZURE_TENANT_ID -v"
 Start-Process -FilePath $venvPythonPath -ArgumentList $argumentList -Wait -NoNewWindow

--- a/scripts/prepdocs.ps1
+++ b/scripts/prepdocs.ps1
@@ -33,5 +33,6 @@ $argumentList = "./scripts/prepdocs.py `"$cwd/data/*`" $adlsGen2StorageAccountAr
 "--openaiservice `"$env:AZURE_OPENAI_SERVICE`" --openaikey `"$env:OPENAI_API_KEY`" " + `
 "--openaiorg `"$env:OPENAI_ORGANIZATION`" --openaideployment `"$env:AZURE_OPENAI_EMB_DEPLOYMENT`" " + `
 "--openaimodelname `"$env:AZURE_OPENAI_EMB_MODEL_NAME`" --index $env:AZURE_SEARCH_INDEX " + `
-"--formrecognizerservice $env:AZURE_FORMRECOGNIZER_SERVICE --tenantid $env:AZURE_TENANT_ID -v"
+"--formrecognizerservice $env:AZURE_FORMRECOGNIZER_SERVICE --tenantid $env:AZURE_TENANT_ID" + `
+"--openaihost $env:OPENAI_HOST --openaikey $env:OPENAI_API_KEY -v"
 Start-Process -FilePath $venvPythonPath -ArgumentList $argumentList -Wait -NoNewWindow

--- a/scripts/prepdocs.sh
+++ b/scripts/prepdocs.sh
@@ -24,4 +24,5 @@ $aclArg  --storageaccount "$AZURE_STORAGE_ACCOUNT" \
 --openaiservice "$AZURE_OPENAI_SERVICE" --openaideployment "$AZURE_OPENAI_EMB_DEPLOYMENT" \
 --openaimodelname "$AZURE_OPENAI_EMB_MODEL_NAME" --index "$AZURE_SEARCH_INDEX" \
 --formrecognizerservice "$AZURE_FORMRECOGNIZER_SERVICE" --openaimodelname "$AZURE_OPENAI_EMB_MODEL_NAME" \
---tenantid "$AZURE_TENANT_ID" -v
+--tenantid "$AZURE_TENANT_ID" --openaihost "$OPENAI_HOST" \
+--openaikey "$OPENAI_API_KEY" -v


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Commit [c8b8486](https://github.com/Azure-Samples/azure-search-openai-demo/commit/c8b8486d68527026b0660a3a75cc4e5e376793c1) removed two command line arguments to the `prepdocs.sh` and `prepdocs.ps1` scripts which break the document loading process for users of the external OpenAI connection. This has been addressed in the open issue #676 
* I added the two arguments (`openaihost` and `openaikey`) back into the file, fixing the problem.
* Based on the logic of `prepdocs.py` (specifically lines 736-752), I don't believe the change will impact users of the Azure OpenAI service. However, I don't have access, so I cannot test this. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
Run `azd up` and specifically watch the `prepdocs` process. There should be no errors for users of the external OpenAI connection.

## What to Check
Verify that the following are valid
* I only have the ability to run in a Linux environment with 3rd party OpenAI connection. 
* It would help for a maintainer to validate that the change (1) doesn't affect users of the Azure OpenAI service, and (2) the changes to `prepdocs.ps1` solve the issue for Windows users.

## Other Information
<!-- Add any other helpful information that may be needed here. -->