### PR TITLE
Fix bug due to "bot" being used instead of "assistant" in Chat.tsx

### DIFF
--- a/app/frontend/src/pages/chat/Chat.tsx
+++ b/app/frontend/src/pages/chat/Chat.tsx
@@ -103,7 +103,7 @@ const Chat = () => {
         try {
             const messages: ResponseMessage[] = answers.flatMap(a => ([
                 { content: a[0], role: "user" },
-                { content: a[1].choices[0].message.content, role: "bot" }
+                { content: a[1].choices[0].message.content, role: "assistant" }
             ]));
 
             const request: ChatAppRequest = {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
After updating my code after recent change (PR to fix chat history context bug, #778), I found that I was getting `TypeError: Cannot read properties of undefined (reading '0')` after asking follow-up questions in the chat. This is the same error as #814 and #770, and I believe are likely related.

I enabled "Application Insights" and found this as the stack trace:

```Traceback (most recent call last):
  File "/tmp/8dbcf8b8d2431d2/antenv/lib/python3.11/site-packages/opentelemetry/trace/__init__.py", line 573, in use_span
    yield span
  File "/tmp/8dbcf8b8d2431d2/antenv/lib/python3.11/site-packages/opentelemetry/instrumentation/asgi/__init__.py", line 596, in __call__
    await self.app(scope, otel_receive, otel_send)
  File "/tmp/8dbcf8b8d2431d2/antenv/lib/python3.11/site-packages/quart/app.py", line 1647, in asgi_app
    await asgi_handler(receive, send)
  File "/tmp/8dbcf8b8d2431d2/antenv/lib/python3.11/site-packages/quart/asgi.py", line 52, in __call__
    raise_task_exceptions(done)
  File "/tmp/8dbcf8b8d2431d2/antenv/lib/python3.11/site-packages/quart/utils.py", line 187, in raise_task_exceptions
    raise task.exception()
  File "/tmp/8dbcf8b8d2431d2/antenv/lib/python3.11/site-packages/quart/asgi.py", line 107, in handle_request
    await asyncio.wait_for(self._send_response(send, response), timeout=timeout)
  File "/opt/python/3.11.4/lib/python3.11/asyncio/tasks.py", line 442, in wait_for
    return await fut
           ^^^^^^^^^
  File "/tmp/8dbcf8b8d2431d2/antenv/lib/python3.11/site-packages/quart/asgi.py", line 134, in _send_response
    async for data in response_body:
  File "/tmp/8dbcf8b8d2431d2/app.py", line 109, in format_as_ndjson
    async for event in r:
  File "/tmp/8dbcf8b8d2431d2/approaches/chatreadretrieveread.py", line 256, in run_with_streaming
    extra_info, chat_coroutine = await self.run_until_final_call(
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/8dbcf8b8d2431d2/approaches/chatreadretrieveread.py", line 126, in run_until_final_call
    chat_completion = await openai.ChatCompletion.acreate(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/8dbcf8b8d2431d2/antenv/lib/python3.11/site-packages/openai/api_resources/chat_completion.py", line 45, in acreate
    return await super().acreate(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/8dbcf8b8d2431d2/antenv/lib/python3.11/site-packages/openai/api_resources/abstract/engine_api_resource.py", line 219, in acreate
    response, _, api_key = await requestor.arequest(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/8dbcf8b8d2431d2/antenv/lib/python3.11/site-packages/openai/api_requestor.py", line 384, in arequest
    resp, got_stream = await self._interpret_async_response(result, stream)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/8dbcf8b8d2431d2/antenv/lib/python3.11/site-packages/openai/api_requestor.py", line 738, in _interpret_async_response
    self._interpret_response_line(
  File "/tmp/8dbcf8b8d2431d2/antenv/lib/python3.11/site-packages/openai/api_requestor.py", line 775, in _interpret_response_line
    raise self.handle_error_response(
openai.error.InvalidRequestError: 'bot' is not one of ['system', 'assistant', 'user', 'function'] - 'messages.6.role'
```
A simple search in the repo found the only location of "bot" was in the `app/frontend/src/pages/chat/Chat.tsx` file, line 106.

I changed 

```
            const messages: ResponseMessage[] = answers.flatMap(a => ([
                { content: a[0], role: "user" },
                { content: a[1].choices[0].message.content, role: "bot" }
            ]));
```
to

```            
            const messages: ResponseMessage[] = answers.flatMap(a => ([
                { content: a[0], role: "user" },
                { content: a[1].choices[0].message.content, role: "assistant" }
            ]));
```
and re-deployed. Problem solved!

I think this PR may fix #814 and #770. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
```

## How to Test
* Replicate original bug by simply deploying current commit. Confirm that follow-up questions introduce bug.
* Change "bot" to "assistant" and re-deploy. Confirm that follow-up questions work.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
Tested in dev-container. Running Ubuntu 22.04.