### PR TITLE
Store an MD5 hash of uploaded/indexed file and check before prepdocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,5 @@ cython_debug/
 npm-debug.log*
 node_modules
 static/
+
+data/*.md5

--- a/scripts/prepdocs.py
+++ b/scripts/prepdocs.py
@@ -525,7 +525,7 @@ def read_files(
                 with open(filename, 'rb') as file:
                     existing_hash = hashlib.md5(file.read()).hexdigest()
                 if os.path.exists(filename + ".md5"):
-                    with open(filename + ".md5", "r", encoding="utf-8") as md5_f:
+                    with open(filename + ".md5", encoding="utf-8") as md5_f:
                         stored_hash = md5_f.read()
 
                 if stored_hash and stored_hash.strip() == existing_hash.strip():

--- a/scripts/prepdocs.py
+++ b/scripts/prepdocs.py
@@ -527,14 +527,14 @@ def read_files(
                 if os.path.exists(filename + ".md5"):
                     with open(filename + ".md5", "r", encoding="utf-8") as md5_f:
                         stored_hash = md5_f.read()
-                else:
-                    # Write the hash
-                    with open(filename + ".md5", "w", encoding="utf-8") as md5_f:
-                        md5_f.write(existing_hash)
 
                 if stored_hash and stored_hash.strip() == existing_hash.strip():
                     print("Skipping {filename}, no changes detected")
                     continue
+                else:
+                    # Write the hash
+                    with open(filename + ".md5", "w", encoding="utf-8") as md5_f:
+                        md5_f.write(existing_hash)
 
                 if not args.skipblobs:
                     upload_blobs(filename)

--- a/scripts/prepdocs.py
+++ b/scripts/prepdocs.py
@@ -518,7 +518,6 @@ def read_files(
             try:
                 # if filename ends in .md5 skip
                 if filename.endswith(".md5"):
-                    print("Skipping md5 hash index.")
                     continue
 
                 # if there is a file called .md5 in this directory, see if its updated

--- a/scripts/prepdocs.py
+++ b/scripts/prepdocs.py
@@ -518,6 +518,7 @@ def read_files(
             try:
                 # if filename ends in .md5 skip
                 if filename.endswith('.md5'):
+                    print("Skipping md5 hash index.")
                     continue
 
                 # if there is a file called .md5 in this directory, see if its updated
@@ -529,7 +530,7 @@ def read_files(
                         stored_hash = md5_f.read()
 
                 if stored_hash and stored_hash.strip() == existing_hash.strip():
-                    print("Skipping {filename}, no changes detected")
+                    print(f"Skipping {filename}, no changes detected.")
                     continue
                 else:
                     # Write the hash

--- a/scripts/prepdocs.py
+++ b/scripts/prepdocs.py
@@ -1,6 +1,7 @@
 import argparse
 import base64
 import glob
+import hashlib
 import html
 import io
 import os
@@ -515,6 +516,26 @@ def read_files(
                 read_files(filename + "/*", use_vectors, vectors_batch_support)
                 continue
             try:
+                # if filename ends in .md5 skip
+                if filename.endswith('.md5'):
+                    continue
+
+                # if there is a file called .md5 in this directory, see if its updated
+                stored_hash = None
+                with open(filename, 'rb') as file:
+                    existing_hash = hashlib.md5(file.read()).hexdigest()
+                if os.path.exists(filename + ".md5"):
+                    with open(filename + ".md5", "r", encoding="utf-8") as md5_f:
+                        stored_hash = md5_f.read()
+                else:
+                    # Write the hash
+                    with open(filename + ".md5", "w", encoding="utf-8") as md5_f:
+                        md5_f.write(existing_hash)
+
+                if stored_hash and stored_hash.strip() == existing_hash.strip():
+                    print("Skipping {filename}, no changes detected")
+                    continue
+
                 if not args.skipblobs:
                     upload_blobs(filename)
                 page_map = get_document_text(filename)

--- a/scripts/prepdocs.py
+++ b/scripts/prepdocs.py
@@ -517,13 +517,13 @@ def read_files(
                 continue
             try:
                 # if filename ends in .md5 skip
-                if filename.endswith('.md5'):
+                if filename.endswith(".md5"):
                     print("Skipping md5 hash index.")
                     continue
 
                 # if there is a file called .md5 in this directory, see if its updated
                 stored_hash = None
-                with open(filename, 'rb') as file:
+                with open(filename, "rb") as file:
                     existing_hash = hashlib.md5(file.read()).hexdigest()
                 if os.path.exists(filename + ".md5"):
                     with open(filename + ".md5", encoding="utf-8") as md5_f:


### PR DESCRIPTION

## Purpose
Running prep docs on every provision is really time consuming, especially if the docs haven't changed.

This PR writes an `.md5` file with an MD5 hash of the files in `data/` when they get uploaded, then every time the prep docs script is re-run that file is checked against the current hash and the file is skipped if it hasn't changed.

I've added those md5 files to gitignore so they don't get committed and they also won't be uploaded.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->