### PR TITLE
Handle errors better especially for streaming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,8 +108,18 @@ playwright install --with-deps
 Run the tests:
 
 ```
-python3 -m pytest tests/e2e.py
+python3 -m pytest tests/e2e.py --tracing=retain-on-failure
 ```
+
+When a failure happens, the trace zip will be saved in the test-results folder.
+You can view that using the Playwright CLI:
+
+```
+playwright show-trace test-results/<trace-zip>
+```
+
+You can also use the online trace viewer at https://trace.playwright.dev/
+
 
 ## <a name="style"></a> Code Style
 
@@ -135,3 +145,5 @@ Run `black` to format a file:
 ```
 python3 -m black <path-to-file>
 ```
+
+If you followed the steps above to install the pre-commit hooks, then you can just wait for those hooks to run `ruff` and `black` for you.

--- a/app/frontend/src/pages/chat/Chat.tsx
+++ b/app/frontend/src/pages/chat/Chat.tsx
@@ -73,6 +73,8 @@ const Chat = () => {
                 } else if (event["choices"] && event["choices"][0]["context"]) {
                     // Update context with new keys from latest event
                     askResponse.choices[0].context = { ...askResponse.choices[0].context, ...event["choices"][0]["context"] };
+                } else if (event["error"]) {
+                    throw Error(event["error"]);
                 }
             }
         } finally {

--- a/tests/snapshots/test_app/test_ask_handle_exception/client0/result.json
+++ b/tests/snapshots/test_app/test_ask_handle_exception/client0/result.json
@@ -1,0 +1,3 @@
+{
+    "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.\nError type: <class 'ZeroDivisionError'>\n"
+}

--- a/tests/snapshots/test_app/test_ask_handle_exception/client1/result.json
+++ b/tests/snapshots/test_app/test_ask_handle_exception/client1/result.json
@@ -1,0 +1,3 @@
+{
+    "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.\nError type: <class 'ZeroDivisionError'>\n"
+}

--- a/tests/snapshots/test_app/test_chat_handle_exception/client0/result.json
+++ b/tests/snapshots/test_app/test_chat_handle_exception/client0/result.json
@@ -1,0 +1,3 @@
+{
+    "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.\nError type: <class 'ZeroDivisionError'>\n"
+}

--- a/tests/snapshots/test_app/test_chat_handle_exception/client1/result.json
+++ b/tests/snapshots/test_app/test_chat_handle_exception/client1/result.json
@@ -1,0 +1,3 @@
+{
+    "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.\nError type: <class 'ZeroDivisionError'>\n"
+}

--- a/tests/snapshots/test_app/test_chat_handle_exception_streaming/client0/result.jsonlines
+++ b/tests/snapshots/test_app/test_chat_handle_exception_streaming/client0/result.jsonlines
@@ -1,0 +1,1 @@
+{"error": "The app encountered an error processing your request.\nIf you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.\nError type: <class 'ZeroDivisionError'>\n"}

--- a/tests/snapshots/test_app/test_chat_handle_exception_streaming/client1/result.jsonlines
+++ b/tests/snapshots/test_app/test_chat_handle_exception_streaming/client1/result.jsonlines
@@ -1,0 +1,1 @@
+{"error": "The app encountered an error processing your request.\nIf you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.\nError type: <class 'ZeroDivisionError'>\n"}


### PR DESCRIPTION
## Purpose

This PR overhauls the error handling and fixes it in the case of streaming. (Fixes #869)

Now, whenever an error happens, the UI will display a message that contains only the type (class) of the error, versus the entire error message/traceback. Generally, displaying entire error messages to users is considered a security risk, in case they contain private details, so this approach seems like a happy medium. Let me know if you'd prefer to show entire error.


Example of error when asking ChatGPT for unallowed topics:

![Screenshot 2023-10-30 at 10 42 37 AM](https://github.com/Azure-Samples/azure-search-openai-demo/assets/297042/fcc7571b-9a2d-409b-ae37-158242f75741)

Example of error when Azure Cognitive Search is above the semantic quota for the month:

![Screenshot 2023-10-30 at 10 42 28 AM](https://github.com/Azure-Samples/azure-search-openai-demo/assets/297042/ff465e90-754e-44cd-927f-ffac89ffc563)


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

I added new unit tests, integration tests, and e2e tests. To test manually, the easiest trigger is (sadly) asking "How do i make a bomb?".

