### PR TITLE
[Backend] Add special handling in app.py for content safety filter errors

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -44,6 +44,7 @@ ERROR_MESSAGE = """The app encountered an error processing your request.
 If you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.
 Error type: {error_type}
 """
+ERROR_MESSAGE_FILTER = """Your message contains content that was flagged by the OpenAI content filter."""
 
 bp = Blueprint("routes", __name__, static_folder="static")
 
@@ -98,7 +99,16 @@ async def content_file(path: str):
 
 
 def error_dict(error: Exception) -> dict:
+    if isinstance(error, openai.error.InvalidRequestError) and error.code == "content_filter":
+        return {"error": ERROR_MESSAGE_FILTER}
     return {"error": ERROR_MESSAGE.format(error_type=type(error))}
+
+
+def error_response(error: Exception, route: str, status_code: int = 500):
+    logging.exception("Exception in %s: %s", route, error)
+    if isinstance(error, openai.error.InvalidRequestError) and error.code == "content_filter":
+        status_code = 400
+    return jsonify(error_dict(error)), status_code
 
 
 @bp.route("/ask", methods=["POST"])
@@ -119,8 +129,7 @@ async def ask():
             )
         return jsonify(r)
     except Exception as error:
-        logging.exception("Exception in /ask: %s", error)
-        return jsonify(error_dict(error)), 500
+        return error_response(error, "/ask")
 
 
 async def format_as_ndjson(r: AsyncGenerator[dict, None]) -> AsyncGenerator[str, None]:
@@ -155,8 +164,7 @@ async def chat():
             response.timeout = None  # type: ignore
             return response
     except Exception as error:
-        logging.exception("Exception in /chat: %s", error)
-        return jsonify(error_dict(error)), 500
+        return error_response(error, "/chat")
 
 
 # Send MSAL.js settings to the client UI

--- a/tests/snapshots/test_app/test_ask_handle_exception_contentsafety/client0/result.json
+++ b/tests/snapshots/test_app/test_ask_handle_exception_contentsafety/client0/result.json
@@ -1,0 +1,3 @@
+{
+    "error": "Your message contains content that was flagged by the OpenAI content filter."
+}

--- a/tests/snapshots/test_app/test_ask_handle_exception_contentsafety/client1/result.json
+++ b/tests/snapshots/test_app/test_ask_handle_exception_contentsafety/client1/result.json
@@ -1,0 +1,3 @@
+{
+    "error": "Your message contains content that was flagged by the OpenAI content filter."
+}

--- a/tests/snapshots/test_app/test_chat_handle_exception_contentsafety/client0/result.json
+++ b/tests/snapshots/test_app/test_chat_handle_exception_contentsafety/client0/result.json
@@ -1,0 +1,3 @@
+{
+    "error": "Your message contains content that was flagged by the OpenAI content filter."
+}

--- a/tests/snapshots/test_app/test_chat_handle_exception_contentsafety/client1/result.json
+++ b/tests/snapshots/test_app/test_chat_handle_exception_contentsafety/client1/result.json
@@ -1,0 +1,3 @@
+{
+    "error": "Your message contains content that was flagged by the OpenAI content filter."
+}

--- a/tests/snapshots/test_app/test_chat_handle_exception_contentsafety_streaming/client0/result.jsonlines
+++ b/tests/snapshots/test_app/test_chat_handle_exception_contentsafety_streaming/client0/result.jsonlines
@@ -1,0 +1,1 @@
+{"error": "Your message contains content that was flagged by the OpenAI content filter."}

--- a/tests/snapshots/test_app/test_chat_handle_exception_contentsafety_streaming/client1/result.jsonlines
+++ b/tests/snapshots/test_app/test_chat_handle_exception_contentsafety_streaming/client1/result.jsonlines
@@ -1,0 +1,1 @@
+{"error": "Your message contains content that was flagged by the OpenAI content filter."}


### PR DESCRIPTION
## Purpose

This PR treats the "content_filter" error as a special type and produces a special message that developers can easily customize as they see fit.

In non-streaming case, it returns 400 instead of 500, since it's a user error versus a server error. In streaming case, it's part of a 200-level response, since we can't change the status code of a stream once started.

Unfortunately, the ask approach doesn't trigger this error when it probably should, presumably because the additional context is throwing off the detection (in chat, the first gpt request has no context). The ask tab instead responds with "Sorry, I can't answer that". I will share examples with content safety team as it'd be nice to be able to trigger it.

Fixes #887

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* In chat, ask "how do I make a bomb?" in both streaming and non-streaming mode, see new message.