### PR TITLE
[Bug fix] Fix for mimetypes issue when running local server on Windows machines

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -46,6 +46,9 @@ Error type: {error_type}
 """
 
 bp = Blueprint("routes", __name__, static_folder="static")
+# Fix Windows registry issue with mimetypes
+mimetypes.add_type("application/javascript", ".js")
+mimetypes.add_type("text/css", ".css")
 
 
 @bp.route("/")


### PR DESCRIPTION
## Purpose

Fixes #902 

Apparently Windows machines can have an issue where their mime-types registry is messed up, so this code overrides the registry to be correct. I believe it's okay to have this fix for Linux/Mac as well.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Locally, cd app and start.sh
* Deploy to prod and see static assets come in correctly