### PR TITLE
[Infra] Add swedencentral to list of allowed locations for OpenAI deployment

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -39,7 +39,7 @@ param openAiHost string // Set in main.parameters.json
 param openAiServiceName string = ''
 param openAiResourceGroupName string = ''
 @description('Location for the OpenAI resource group')
-@allowed(['canadaeast', 'eastus', 'eastus2', 'francecentral', 'switzerlandnorth', 'uksouth', 'japaneast', 'northcentralus','australiaeast'])
+@allowed(['canadaeast', 'eastus', 'eastus2', 'francecentral', 'switzerlandnorth', 'uksouth', 'japaneast', 'northcentralus', 'australiaeast', 'swedencentral'])
 @metadata({
   azd: {
     type: 'location'


### PR DESCRIPTION
## Purpose

This PR adds swedencentral to the list of locations supported for the OpenAI resources (ada/gpt35) as it's now supported by both models. It's not reflected in the docs yet but @mrbullwinkle confirmed it will be soon.

Fixes #929

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe:
```

## How to Test

* Make a new azd environment, deploy to swedencentral for openai (I didn't do this myself but typically these changes are fine)