### PR TITLE
set content-type for streamed response

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -165,6 +165,7 @@ async def chat():
         else:
             response = await make_response(format_as_ndjson(result))
             response.timeout = None  # type: ignore
+            response.mimetype = "application/json"
             return response
     except Exception as error:
         return error_response(error, "/chat")

--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -165,7 +165,7 @@ async def chat():
         else:
             response = await make_response(format_as_ndjson(result))
             response.timeout = None  # type: ignore
-            response.mimetype = "application/json"
+            response.mimetype = "application/json-lines"
             return response
     except Exception as error:
         return error_response(error, "/chat")


### PR DESCRIPTION
## Purpose
This PR changes the Content-Type of responses from the endpoint **/chat**. Previously, streamed responses where sent as  **text/html; charset=utf-8**, now they would be sent as **application/json**

## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[ ] Feature
[X] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Do a request to the **/chat** endpoint and see that the Content-Type is different in the response header