### PR TITLE
Fix ignored capacity field for openAI deployment

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -214,7 +214,10 @@ module openAi 'core/ai/cognitiveservices.bicep' = if (openAiHost == 'azure') {
           name: embeddingModelName
           version: '2'
         }
-        capacity: embeddingDeploymentCapacity
+        sku: {
+          name: 'Standard'
+          capacity: embeddingDeploymentCapacity
+        }
       }
     ]
   }


### PR DESCRIPTION
The field `capacity` can't be directly used at the root level of a deployment object for the cognitive services module.

The module expects either the node `sku` or nothing:

```
sku: contains(deployment, 'sku') ? deployment.sku : {
    name: 'Standard'
    capacity: 20
  }
```

This PR won't change any functionality, as the default value for sku provided by the module is currently equal to the value set in main.bicep.  But fixes the bug for any user trying to use the capacity field with other value, as it is ignored