### PR TITLE
[Bug fix] Fix prepdocs logic in uploading docs with more than 1000 sections

### DIFF
--- a/scripts/prepdocslib/searchmanager.py
+++ b/scripts/prepdocslib/searchmanager.py
@@ -122,10 +122,10 @@ class SearchManager:
         section_batches = [sections[i : i + MAX_BATCH_SIZE] for i in range(0, len(sections), MAX_BATCH_SIZE)]
 
         async with self.search_info.create_search_client() as search_client:
-            for batch in section_batches:
+            for batch_index, batch in enumerate(section_batches):
                 documents = [
                     {
-                        "id": f"{section.content.filename_to_id()}-page-{i}",
+                        "id": f"{section.content.filename_to_id()}-page-{section_index + batch_index * MAX_BATCH_SIZE}",
                         "content": section.split_page.text,
                         "category": section.category,
                         "sourcepage": BlobManager.sourcepage_from_file_page(
@@ -134,7 +134,7 @@ class SearchManager:
                         "sourcefile": section.content.filename(),
                         **section.content.acls,
                     }
-                    for i, section in enumerate(batch)
+                    for section_index, section in enumerate(batch)
                 ]
                 if self.embeddings:
                     embeddings = await self.embeddings.create_embeddings(

--- a/tests/test_searchmanager.py
+++ b/tests/test_searchmanager.py
@@ -1,0 +1,91 @@
+import io
+
+import pytest
+from azure.core.credentials import AzureKeyCredential
+from azure.search.documents.aio import SearchClient
+
+from scripts.prepdocslib.listfilestrategy import File
+from scripts.prepdocslib.searchmanager import SearchManager, Section
+from scripts.prepdocslib.strategy import SearchInfo
+from scripts.prepdocslib.textsplitter import SplitPage
+
+
+@pytest.mark.asyncio
+async def test_update_content(monkeypatch):
+    async def mock_upload_documents(self, documents):
+        assert len(documents) == 1
+        assert documents[0]["id"] == "file-foo_pdf-666F6F2E706466-page-0"
+        assert documents[0]["content"] == "test content"
+        assert documents[0]["category"] == "test"
+        assert documents[0]["sourcepage"] == "foo.pdf#page=1"
+        assert documents[0]["sourcefile"] == "foo.pdf"
+
+    monkeypatch.setattr(SearchClient, "upload_documents", mock_upload_documents)
+
+    manager = SearchManager(
+        SearchInfo(
+            endpoint="https://testsearchclient.blob.core.windows.net",
+            credential=AzureKeyCredential("test"),
+            index_name="test",
+            verbose=True,
+        )
+    )
+
+    test_io = io.BytesIO(b"test content")
+    test_io.name = "test/foo.pdf"
+    file = File(test_io)
+
+    await manager.update_content(
+        [
+            Section(
+                split_page=SplitPage(
+                    page_num=0,
+                    text="test content",
+                ),
+                content=file,
+                category="test",
+            )
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_content_many(monkeypatch):
+    ids = []
+
+    async def mock_upload_documents(self, documents):
+        ids.extend([doc["id"] for doc in documents])
+
+    monkeypatch.setattr(SearchClient, "upload_documents", mock_upload_documents)
+
+    manager = SearchManager(
+        SearchInfo(
+            endpoint="https://testsearchclient.blob.core.windows.net",
+            credential=AzureKeyCredential("test"),
+            index_name="test",
+            verbose=True,
+        )
+    )
+
+    # create 1500 sections for 500 pages
+    sections = []
+    test_io = io.BytesIO(b"test page")
+    test_io.name = "test/foo.pdf"
+    file = File(test_io)
+    for page_num in range(500):
+        for page_section_num in range(3):
+            sections.append(
+                Section(
+                    split_page=SplitPage(
+                        page_num=page_num,
+                        text=f"test section {page_section_num}",
+                    ),
+                    content=file,
+                    category="test",
+                )
+            )
+
+    await manager.update_content(sections)
+
+    assert len(ids) == 1500, "Wrong number of documents uploaded"
+    assert len(set(ids)) == 1500, "Document ids are not unique"

--- a/tests/test_searchmanager.py
+++ b/tests/test_searchmanager.py
@@ -225,3 +225,60 @@ async def test_update_content_with_embeddings(monkeypatch, search_info):
         -0.009327292,
         -0.0028842222,
     ]
+
+
+@pytest.mark.asyncio
+async def test_remove_content(monkeypatch, search_info):
+    class AsyncSearchResultsIterator:
+        def __init__(self):
+            self.results = [
+                {
+                    "@search.score": 1,
+                    "id": "file-foo_pdf-666F6F2E706466-page-0",
+                    "content": "test content",
+                    "category": "test",
+                    "sourcepage": "foo.pdf#page=1",
+                    "sourcefile": "foo.pdf",
+                }
+            ]
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if len(self.results) == 0:
+                raise StopAsyncIteration
+            return self.results.pop()
+
+        async def get_count(self):
+            return len(self.results)
+
+    search_results = AsyncSearchResultsIterator()
+
+    searched_filters = []
+
+    async def mock_search(self, *args, **kwargs):
+        self.filter = kwargs.get("filter")
+        searched_filters.append(self.filter)
+        return search_results
+
+    monkeypatch.setattr(SearchClient, "search", mock_search)
+
+    deleted_documents = []
+
+    async def mock_delete_documents(self, documents):
+        deleted_documents.extend(documents)
+        return documents
+
+    monkeypatch.setattr(SearchClient, "delete_documents", mock_delete_documents)
+
+    manager = SearchManager(
+        search_info,
+    )
+    print(manager.search_info.index_name)
+    await manager.remove_content("foo.pdf")
+
+    assert len(searched_filters) == 2, "It should have searched twice (with no results on second try)"
+    assert searched_filters[0] == "sourcefile eq 'foo.pdf'"
+    assert len(deleted_documents) == 1, "It should have deleted one document"
+    assert deleted_documents[0]["id"] == "file-foo_pdf-666F6F2E706466-page-0"

--- a/tests/test_searchmanager.py
+++ b/tests/test_searchmanager.py
@@ -275,7 +275,7 @@ async def test_remove_content(monkeypatch, search_info):
     manager = SearchManager(
         search_info,
     )
-    print(manager.search_info.index_name)
+
     await manager.remove_content("foo.pdf")
 
     assert len(searched_filters) == 2, "It should have searched twice (with no results on second try)"


### PR DESCRIPTION
## Purpose

Fixes #960 and adds tests. The issue was that later document IDs were overriding earlier ones.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Run pytest