### PR TITLE
[BugFix] Use default font when a specific font cannot be found

### DIFF
--- a/scripts/prepdocslib/blobmanager.py
+++ b/scripts/prepdocslib/blobmanager.py
@@ -84,7 +84,11 @@ class BlobManager:
             try:
                 font = ImageFont.truetype("arial.ttf", 20)
             except OSError:
-                font = ImageFont.truetype("/usr/share/fonts/truetype/freefont/FreeMono.ttf", 20)
+                try:
+                    font = ImageFont.truetype("/usr/share/fonts/truetype/freefont/FreeMono.ttf", 20)
+                except OSError:
+                    print("Unable to find arial.ttf or FreeMono.ttf, using default font")
+
             draw = ImageDraw.Draw(new_img)
             text = f"SourceFileName:{blob_name}"
 

--- a/scripts/prepdocslib/blobmanager.py
+++ b/scripts/prepdocslib/blobmanager.py
@@ -81,6 +81,7 @@ class BlobManager:
             new_img.paste(original_img, (0, text_height))
 
             # Draw the text on the white area
+            font = None
             try:
                 font = ImageFont.truetype("arial.ttf", 20)
             except OSError:

--- a/scripts/prepdocslib/blobmanager.py
+++ b/scripts/prepdocslib/blobmanager.py
@@ -63,6 +63,15 @@ class BlobManager:
         start_time = datetime.datetime.now(datetime.timezone.utc)
         expiry_time = start_time + datetime.timedelta(days=1)
 
+        font = None
+        try:
+            font = ImageFont.truetype("arial.ttf", 20)
+        except OSError:
+            try:
+                font = ImageFont.truetype("/usr/share/fonts/truetype/freefont/FreeMono.ttf", 20)
+            except OSError:
+                print("\tUnable to find arial.ttf or FreeMono.ttf, using default font")
+
         for i in range(page_count):
             blob_name = BlobManager.blob_image_name_from_file_page(file.content.name, i)
             if self.verbose:
@@ -81,15 +90,6 @@ class BlobManager:
             new_img.paste(original_img, (0, text_height))
 
             # Draw the text on the white area
-            font = None
-            try:
-                font = ImageFont.truetype("arial.ttf", 20)
-            except OSError:
-                try:
-                    font = ImageFont.truetype("/usr/share/fonts/truetype/freefont/FreeMono.ttf", 20)
-                except OSError:
-                    print("Unable to find arial.ttf or FreeMono.ttf, using default font")
-
             draw = ImageDraw.Draw(new_img)
             text = f"SourceFileName:{blob_name}"
 


### PR DESCRIPTION
## Purpose

Fixes #1068

The default font seemed to work on my system, though I don't now if GPT-4v finds some fonts easier than others.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Run ./scripts/prepdocs.sh on a system that doesnt have those other fonts, See:

```
Splitting 'Financial Market Analysis Report 2023.pdf' into sections
        Uploading blob for whole file -> Financial Market Analysis Report 2023.pdf
        Unable to find arial.ttf or FreeMono.ttf, using default font
        Converting page 0 to image and uploading -> Financial Market Analysis Report 2023-0.png
```

* Load app, use gpt4v, and see filename at top of image in citation