### PR TITLE
bugfix:  fix the same variable was used twice in the judgment

### DIFF
--- a/app/backend/core/authentication.py
+++ b/app/backend/core/authentication.py
@@ -116,7 +116,7 @@ class AuthenticationHelper:
         use_oid_security_filter = self.require_access_control or overrides.get("use_oid_security_filter")
         use_groups_security_filter = self.require_access_control or overrides.get("use_groups_security_filter")
 
-        if (use_oid_security_filter or use_oid_security_filter) and not self.has_auth_fields:
+        if (use_oid_security_filter or use_groups_security_filter) and not self.has_auth_fields:
             raise AuthError(
                 error="oids and groups must be defined in the search index to use authentication", status_code=400
             )


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* The judgment should have verified groups and oids, but the existing judgment criteria only include verifying oid.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
origin line:
```
if (use_oid_security_filter or use_oid_security_filter) and not self.has_auth_fields:
```
There are two 'use_oid_security_filter' before and after
fixed line:
```
if (use_oid_security_filter or use_groups_security_filter) and not self.has_auth_fields:
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
* I am sorry that I discovered this logical error by reading the code, so there is no existing method for testing.