### PR TITLE
Update Authentication to use local storage and easy auth refresh

### DIFF
--- a/app/backend/core/authentication.py
+++ b/app/backend/core/authentication.py
@@ -65,9 +65,11 @@ class AuthenticationHelper:
                     "navigateToLoginRequestUrl": False,  # If "true", will navigate back to the original request location before processing the auth code response.
                 },
                 "cache": {
-                    "cacheLocation": "sessionStorage",
+                    # Configures cache location. "sessionStorage" is more secure, but "localStorage" gives you SSO between tabs.
+                    "cacheLocation": "localStorage",
+                    # Set this to "true" if you are having issues on IE11 or Edge
                     "storeAuthStateInCookie": False,
-                },  # Configures cache location. "sessionStorage" is more secure, but "localStorage" gives you SSO between tabs.  # Set this to "true" if you are having issues on IE11 or Edge
+                },
             },
             "loginRequest": {
                 # Scopes you add here will be prompted for user consent during sign-in.

--- a/app/frontend/src/authConfig.ts
+++ b/app/frontend/src/authConfig.ts
@@ -89,35 +89,32 @@ export const getRedirectUri = () => {
 // Get an access token if a user logged in using app services authentication
 // Returns null if the app doesn't support app services authentication
 const getAppServicesToken = (): Promise<AppServicesToken | null> => {
-    return fetch(appServicesAuthTokenRefreshUrl)
-        .then(r => {
-            if (r.ok) {
-                return fetch(appServicesAuthTokenUrl)
-                    .then(r => {
-                        if (r.ok) {
-                            return r.json()
-                                .then(json => {
-                                    if (json.length > 0) {
-                                        return {
-                                            id_token: json[0]["id_token"] as string,
-                                            access_token: json[0]["access_token"] as string,
-                                            user_claims: json[0]["user_claims"].reduce((acc: Record<string, any>, item: Record<string, any>) => {
-                                                acc[item.typ] = item.val;
-                                                return acc;
-                                            }, {}) as Record<string, any>
-                                        };
-                                    }
-
-                                    return null;
-                                });
+    return fetch(appServicesAuthTokenRefreshUrl).then(r => {
+        if (r.ok) {
+            return fetch(appServicesAuthTokenUrl).then(r => {
+                if (r.ok) {
+                    return r.json().then(json => {
+                        if (json.length > 0) {
+                            return {
+                                id_token: json[0]["id_token"] as string,
+                                access_token: json[0]["access_token"] as string,
+                                user_claims: json[0]["user_claims"].reduce((acc: Record<string, any>, item: Record<string, any>) => {
+                                    acc[item.typ] = item.val;
+                                    return acc;
+                                }, {}) as Record<string, any>
+                            };
                         }
 
                         return null;
                     });
-            }
+                }
 
-            return null;
-        });
+                return null;
+            });
+        }
+
+        return null;
+    });
 };
 
 export const appServicesToken = await getAppServicesToken();

--- a/app/frontend/src/authConfig.ts
+++ b/app/frontend/src/authConfig.ts
@@ -3,6 +3,7 @@
 import { IPublicClientApplication } from "@azure/msal-browser";
 
 const appServicesAuthTokenUrl = ".auth/me";
+const appServicesAuthTokenRefreshUrl = ".auth/refresh";
 const appServicesAuthLogoutUrl = ".auth/logout?post_logout_redirect_uri=/";
 
 interface AppServicesToken {
@@ -88,26 +89,35 @@ export const getRedirectUri = () => {
 // Get an access token if a user logged in using app services authentication
 // Returns null if the app doesn't support app services authentication
 const getAppServicesToken = (): Promise<AppServicesToken | null> => {
-    return fetch(appServicesAuthTokenUrl).then(r => {
-        if (r.ok) {
-            return r.json().then(json => {
-                if (json.length > 0) {
-                    return {
-                        id_token: json[0]["id_token"] as string,
-                        access_token: json[0]["access_token"] as string,
-                        user_claims: json[0]["user_claims"].reduce((acc: Record<string, any>, item: Record<string, any>) => {
-                            acc[item.typ] = item.val;
-                            return acc;
-                        }, {}) as Record<string, any>
-                    };
-                }
+    return fetch(appServicesAuthTokenRefreshUrl)
+        .then(r => {
+            if (r.ok) {
+                return fetch(appServicesAuthTokenUrl)
+                    .then(r => {
+                        if (r.ok) {
+                            return r.json()
+                                .then(json => {
+                                    if (json.length > 0) {
+                                        return {
+                                            id_token: json[0]["id_token"] as string,
+                                            access_token: json[0]["access_token"] as string,
+                                            user_claims: json[0]["user_claims"].reduce((acc: Record<string, any>, item: Record<string, any>) => {
+                                                acc[item.typ] = item.val;
+                                                return acc;
+                                            }, {}) as Record<string, any>
+                                        };
+                                    }
 
-                return null;
-            });
-        }
+                                    return null;
+                                });
+                        }
 
-        return null;
-    });
+                        return null;
+                    });
+            }
+
+            return null;
+        });
 };
 
 export const appServicesToken = await getAppServicesToken();

--- a/tests/test_authenticationhelper.py
+++ b/tests/test_authenticationhelper.py
@@ -80,7 +80,7 @@ def test_auth_setup(mock_confidential_client_success):
                 "postLogoutRedirectUri": "/",
                 "navigateToLoginRequestUrl": False,
             },
-            "cache": {"cacheLocation": "sessionStorage", "storeAuthStateInCookie": False},
+            "cache": {"cacheLocation": "localStorage", "storeAuthStateInCookie": False},
         },
         "loginRequest": {
             "scopes": [".default"],
@@ -104,7 +104,7 @@ def test_auth_setup_required_access_control(mock_confidential_client_success):
                 "postLogoutRedirectUri": "/",
                 "navigateToLoginRequestUrl": False,
             },
-            "cache": {"cacheLocation": "sessionStorage", "storeAuthStateInCookie": False},
+            "cache": {"cacheLocation": "localStorage", "storeAuthStateInCookie": False},
         },
         "loginRequest": {
             "scopes": [".default"],


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Ensure tokens are refreshed when using easy auth so the full refresh window is used before requiring login again
* Store tokens in local storage so sessions are preserved across tabs


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
*  Get the code
*  Validate .auth/refresh is called when logging into the app using the network tab on developer settings
* Validate auth_setup shows localStorage as the msal cache location


