### PR TITLE
bug #1152: Fix for indexing small docs

### DIFF
--- a/app/frontend/src/pages/chat/Chat.tsx
+++ b/app/frontend/src/pages/chat/Chat.tsx
@@ -90,7 +90,7 @@ const Chat = () => {
             for await (const event of readNDJSONStream(responseBody)) {
                 if (event["choices"] && event["choices"][0]["context"] && event["choices"][0]["context"]["data_points"]) {
                     event["choices"][0]["message"] = event["choices"][0]["delta"];
-                    askResponse = event;
+                    askResponse = event as ChatAppResponse;
                 } else if (event["choices"] && event["choices"][0]["delta"]["content"]) {
                     setIsLoading(false);
                     await updateState(event["choices"][0]["delta"]["content"]);

--- a/scripts/prepdocslib/textsplitter.py
+++ b/scripts/prepdocslib/textsplitter.py
@@ -44,7 +44,7 @@ class TextSplitter:
         length = len(all_text)
 
         if length <= self.max_section_length:
-            yield (all_text, find_page(0))
+            yield SplitPage(page_num=find_page(0), text=all_text)
         else:
             start = 0
             end = length

--- a/scripts/prepdocslib/textsplitter.py
+++ b/scripts/prepdocslib/textsplitter.py
@@ -1,5 +1,4 @@
 from typing import Generator, List
-
 from .pdfparser import Page
 
 

--- a/scripts/prepdocslib/textsplitter.py
+++ b/scripts/prepdocslib/textsplitter.py
@@ -40,8 +40,10 @@ class TextSplitter:
             return pages[num_pages - 1].page_num
 
         all_text = "".join(page.text for page in pages)
-        length = len(all_text)
+        if len(all_text.strip()) == 0:
+            return
 
+        length = len(all_text)
         if length <= self.max_section_length:
             yield SplitPage(page_num=find_page(0), text=all_text)
         else:

--- a/scripts/prepdocslib/textsplitter.py
+++ b/scripts/prepdocslib/textsplitter.py
@@ -42,59 +42,63 @@ class TextSplitter:
 
         all_text = "".join(page.text for page in pages)
         length = len(all_text)
-        start = 0
-        end = length
-        while start + self.section_overlap < length:
-            last_word = -1
-            end = start + self.max_section_length
 
-            if end > length:
-                end = length
-            else:
-                # Try to find the end of the sentence
-                while (
-                    end < length
-                    and (end - start - self.max_section_length) < self.sentence_search_limit
-                    and all_text[end] not in self.sentence_endings
-                ):
-                    if all_text[end] in self.word_breaks:
-                        last_word = end
+        if length <= self.max_section_length:
+            yield (all_text, find_page(0))
+        else:
+            start = 0
+            end = length
+            while start + self.section_overlap < length:
+                last_word = -1
+                end = start + self.max_section_length
+
+                if end > length:
+                    end = length
+                else:
+                    # Try to find the end of the sentence
+                    while (
+                        end < length
+                        and (end - start - self.max_section_length) < self.sentence_search_limit
+                        and all_text[end] not in self.sentence_endings
+                    ):
+                        if all_text[end] in self.word_breaks:
+                            last_word = end
+                        end += 1
+                    if end < length and all_text[end] not in self.sentence_endings and last_word > 0:
+                        end = last_word  # Fall back to at least keeping a whole word
+                if end < length:
                     end += 1
-                if end < length and all_text[end] not in self.sentence_endings and last_word > 0:
-                    end = last_word  # Fall back to at least keeping a whole word
-            if end < length:
-                end += 1
 
-            # Try to find the start of the sentence or at least a whole word boundary
-            last_word = -1
-            while (
-                start > 0
-                and start > end - self.max_section_length - 2 * self.sentence_search_limit
-                and all_text[start] not in self.sentence_endings
-            ):
-                if all_text[start] in self.word_breaks:
-                    last_word = start
-                start -= 1
-            if all_text[start] not in self.sentence_endings and last_word > 0:
-                start = last_word
-            if start > 0:
-                start += 1
+                # Try to find the start of the sentence or at least a whole word boundary
+                last_word = -1
+                while (
+                    start > 0
+                    and start > end - self.max_section_length - 2 * self.sentence_search_limit
+                    and all_text[start] not in self.sentence_endings
+                ):
+                    if all_text[start] in self.word_breaks:
+                        last_word = start
+                    start -= 1
+                if all_text[start] not in self.sentence_endings and last_word > 0:
+                    start = last_word
+                if start > 0:
+                    start += 1
 
-            section_text = all_text[start:end]
-            yield SplitPage(page_num=find_page(start), text=section_text)
+                section_text = all_text[start:end]
+                yield SplitPage(page_num=find_page(start), text=section_text)
 
-            last_table_start = section_text.rfind("<table")
-            if last_table_start > 2 * self.sentence_search_limit and last_table_start > section_text.rfind("</table"):
-                # If the section ends with an unclosed table, we need to start the next section with the table.
-                # If table starts inside sentence_search_limit, we ignore it, as that will cause an infinite loop for tables longer than MAX_SECTION_LENGTH
-                # If last table starts inside section_overlap, keep overlapping
-                if self.verbose:
-                    print(
-                        f"Section ends with unclosed table, starting next section with the table at page {find_page(start)} offset {start} table start {last_table_start}"
-                    )
-                start = min(end - self.section_overlap, start + last_table_start)
-            else:
-                start = end - self.section_overlap
+                last_table_start = section_text.rfind("<table")
+                if last_table_start > 2 * self.sentence_search_limit and last_table_start > section_text.rfind("</table"):
+                    # If the section ends with an unclosed table, we need to start the next section with the table.
+                    # If table starts inside sentence_search_limit, we ignore it, as that will cause an infinite loop for tables longer than MAX_SECTION_LENGTH
+                    # If last table starts inside section_overlap, keep overlapping
+                    if self.verbose:
+                        print(
+                            f"Section ends with unclosed table, starting next section with the table at page {find_page(start)} offset {start} table start {last_table_start}"
+                        )
+                    start = min(end - self.section_overlap, start + last_table_start)
+                else:
+                    start = end - self.section_overlap
 
-        if start + self.section_overlap < end:
-            yield SplitPage(page_num=find_page(start), text=all_text[start:end])
+            if start + self.section_overlap < end:
+                yield SplitPage(page_num=find_page(start), text=all_text[start:end])

--- a/scripts/prepdocslib/textsplitter.py
+++ b/scripts/prepdocslib/textsplitter.py
@@ -88,7 +88,9 @@ class TextSplitter:
                 yield SplitPage(page_num=find_page(start), text=section_text)
 
                 last_table_start = section_text.rfind("<table")
-                if last_table_start > 2 * self.sentence_search_limit and last_table_start > section_text.rfind("</table"):
+                if last_table_start > 2 * self.sentence_search_limit and last_table_start > section_text.rfind(
+                    "</table"
+                ):
                     # If the section ends with an unclosed table, we need to start the next section with the table.
                     # If table starts inside sentence_search_limit, we ignore it, as that will cause an infinite loop for tables longer than MAX_SECTION_LENGTH
                     # If last table starts inside section_overlap, keep overlapping

--- a/scripts/prepdocslib/textsplitter.py
+++ b/scripts/prepdocslib/textsplitter.py
@@ -47,62 +47,61 @@ class TextSplitter:
         length = len(all_text)
         if length <= self.max_section_length:
             yield SplitPage(page_num=find_page(0), text=all_text)
-        else:
-            start = 0
-            end = length
-            while start + self.section_overlap < length:
-                last_word = -1
-                end = start + self.max_section_length
+            return
 
-                if end > length:
-                    end = length
-                else:
-                    # Try to find the end of the sentence
-                    while (
-                        end < length
-                        and (end - start - self.max_section_length) < self.sentence_search_limit
-                        and all_text[end] not in self.sentence_endings
-                    ):
-                        if all_text[end] in self.word_breaks:
-                            last_word = end
-                        end += 1
-                    if end < length and all_text[end] not in self.sentence_endings and last_word > 0:
-                        end = last_word  # Fall back to at least keeping a whole word
-                if end < length:
-                    end += 1
+        start = 0
+        end = length
+        while start + self.section_overlap < length:
+            last_word = -1
+            end = start + self.max_section_length
 
-                # Try to find the start of the sentence or at least a whole word boundary
-                last_word = -1
+            if end > length:
+                end = length
+            else:
+                # Try to find the end of the sentence
                 while (
-                    start > 0
-                    and start > end - self.max_section_length - 2 * self.sentence_search_limit
-                    and all_text[start] not in self.sentence_endings
+                    end < length
+                    and (end - start - self.max_section_length) < self.sentence_search_limit
+                    and all_text[end] not in self.sentence_endings
                 ):
-                    if all_text[start] in self.word_breaks:
-                        last_word = start
-                    start -= 1
-                if all_text[start] not in self.sentence_endings and last_word > 0:
-                    start = last_word
-                if start > 0:
-                    start += 1
+                    if all_text[end] in self.word_breaks:
+                        last_word = end
+                    end += 1
+                if end < length and all_text[end] not in self.sentence_endings and last_word > 0:
+                    end = last_word  # Fall back to at least keeping a whole word
+            if end < length:
+                end += 1
 
-                section_text = all_text[start:end]
-                yield SplitPage(page_num=find_page(start), text=section_text)
+            # Try to find the start of the sentence or at least a whole word boundary
+            last_word = -1
+            while (
+                start > 0
+                and start > end - self.max_section_length - 2 * self.sentence_search_limit
+                and all_text[start] not in self.sentence_endings
+            ):
+                if all_text[start] in self.word_breaks:
+                    last_word = start
+                start -= 1
+            if all_text[start] not in self.sentence_endings and last_word > 0:
+                start = last_word
+            if start > 0:
+                start += 1
 
-                last_table_start = section_text.rfind("<table")
-                if last_table_start > 2 * self.sentence_search_limit and last_table_start > section_text.rfind(
-                    "</table"
-                ):
-                    # If the section ends with an unclosed table, we need to start the next section with the table.
-                    # If table starts inside sentence_search_limit, we ignore it, as that will cause an infinite loop for tables longer than MAX_SECTION_LENGTH
-                    # If last table starts inside section_overlap, keep overlapping
-                    if self.verbose:
-                        print(
-                            f"Section ends with unclosed table, starting next section with the table at page {find_page(start)} offset {start} table start {last_table_start}"
-                        )
-                    start = min(end - self.section_overlap, start + last_table_start)
-                else:
-                    start = end - self.section_overlap
+            section_text = all_text[start:end]
+            yield SplitPage(page_num=find_page(start), text=section_text)
 
-            if start + self.section_overlap < end:
-                yield SplitPage(page_num=find_page(start), text=all_text[start:end])
+            last_table_start = section_text.rfind("<table")
+            if last_table_start > 2 * self.sentence_search_limit and last_table_start > section_text.rfind("</table"):
+                # If the section ends with an unclosed table, we need to start the next section with the table.
+                # If table starts inside sentence_search_limit, we ignore it, as that will cause an infinite loop for tables longer than MAX_SECTION_LENGTH
+                # If last table starts inside section_overlap, keep overlapping
+                if self.verbose:
+                    print(
+                        f"Section ends with unclosed table, starting next section with the table at page {find_page(start)} offset {start} table start {last_table_start}"
+                    )
+                start = min(end - self.section_overlap, start + last_table_start)
+            else:
+                start = end - self.section_overlap
+
+        if start + self.section_overlap < end:
+            yield SplitPage(page_num=find_page(start), text=all_text[start:end])

--- a/scripts/prepdocslib/textsplitter.py
+++ b/scripts/prepdocslib/textsplitter.py
@@ -1,4 +1,5 @@
 from typing import Generator, List
+
 from .pdfparser import Page
 
 

--- a/tests/test_prepdocslib_textsplitter.py
+++ b/tests/test_prepdocslib_textsplitter.py
@@ -6,13 +6,22 @@ import pytest
 from scripts.prepdocslib.listfilestrategy import LocalListFileStrategy
 from scripts.prepdocslib.pdfparser import LocalPdfParser
 from scripts.prepdocslib.searchmanager import Section
-from scripts.prepdocslib.textsplitter import TextSplitter
+from scripts.prepdocslib.textsplitter import Page, TextSplitter
 
 
 def test_split_empty_pages():
     t = TextSplitter(False, True)
 
     assert list(t.split_pages([])) == []
+
+
+def test_split_small_pages():
+    t = TextSplitter(has_image_embeddings=False, verbose=True)
+
+    split_pages = list(t.split_pages(pages=[Page(page_num=0, offset=0, text="Not a large page")]))
+    assert len(split_pages) == 1
+    assert split_pages[0].page_num == 0
+    assert split_pages[0].text == "Not a large page"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ X] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

It solves the problem with indexing small documents, where amount of text is less than section_overlap. In this case it's enought to check if  amount of text is less than max_section_length and return only one section without additional processing. 
This approach assumes that the section_overlap < max_section_length

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
Index document whith amount of text less than max_section_length

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
Index document whith amount of text less than max_section_length

## What to Check
Verify that the following are valid
After indexing document whith amount of text less than max_section_length, check if document content has been added to the search index

## Other Information
<!-- Add any other helpful information that may be needed here. -->