### PR TITLE
Account for vision key only situation

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -260,8 +260,8 @@ async def setup_clients():
         key_vault_client = SecretClient(
             vault_url=f"https://{AZURE_KEY_VAULT_NAME}.vault.azure.net", credential=azure_credential
         )
-        vision_key = (await key_vault_client.get_secret(VISION_SECRET_NAME)).value
-        search_key = (await key_vault_client.get_secret(SEARCH_SECRET_NAME)).value
+        vision_key = VISION_SECRET_NAME and (await key_vault_client.get_secret(VISION_SECRET_NAME)).value
+        search_key = SEARCH_SECRET_NAME and (await key_vault_client.get_secret(SEARCH_SECRET_NAME)).value
         await key_vault_client.close()
 
     # Set up clients for AI Search and Storage

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -2,8 +2,11 @@ import os
 from unittest import mock
 
 import pytest
+from azure.keyvault.secrets.aio import SecretClient
 
 import app
+
+from .mocks import MockKeyVaultSecret
 
 
 @pytest.fixture
@@ -105,3 +108,39 @@ async def test_app_config_for_client(client):
     assert result["showGPT4VOptions"] == (os.getenv("USE_GPT4V") == "true")
     assert result["showSemanticRankerOption"] is True
     assert result["showVectorOption"] is True
+
+
+@pytest.mark.asyncio
+async def test_app_visionkey_notfound(monkeypatch, minimal_env):
+    monkeypatch.setenv("AZURE_KEY_VAULT_NAME", "my_key_vault")
+    monkeypatch.setenv("VISION_SECRET_NAME", "")
+    monkeypatch.setenv("SEARCH_SECRET_NAME", "search-secret-name")
+
+    async def get_secret(*args, **kwargs):
+        if args[1] == "vision-secret-name":
+            raise Exception("Key not found")
+        return MockKeyVaultSecret("mysecret")
+
+    monkeypatch.setattr(SecretClient, "get_secret", get_secret)
+
+    quart_app = app.create_app()
+    async with quart_app.test_app() as test_app:
+        test_app.test_client()
+
+
+@pytest.mark.asyncio
+async def test_app_searchkey_notfound(monkeypatch, minimal_env):
+    monkeypatch.setenv("AZURE_KEY_VAULT_NAME", "my_key_vault")
+    monkeypatch.setenv("VISION_SECRET_NAME", "vision-secret-name")
+    monkeypatch.setenv("SEARCH_SECRET_NAME", "")
+
+    async def get_secret(*args, **kwargs):
+        if args[1] == "search-secret-name":
+            raise Exception("Key not found")
+        return MockKeyVaultSecret("mysecret")
+
+    monkeypatch.setattr(SecretClient, "get_secret", get_secret)
+
+    quart_app = app.create_app()
+    async with quart_app.test_app() as test_app:
+        test_app.test_client()


### PR DESCRIPTION
## Purpose

This PR fixes an issue introduced by my searchkey PR, where it assumed it could find both the search and vision key at same time. Fixed and added tests.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test


* Run tests
* Run local server in a GPT4-vis environment
* Run local server in a free environment