### PR TITLE
Use token provider instead of token wrapper

### DIFF
--- a/scripts/prepdocslib/embeddings.py
+++ b/scripts/prepdocslib/embeddings.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import List, Optional, Union
+from typing import Awaitable, Callable, List, Optional, Union
 from urllib.parse import urljoin
 
 import aiohttp
@@ -14,6 +14,7 @@ from tenacity import (
     stop_after_attempt,
     wait_random_exponential,
 )
+from typing_extensions import TypedDict
 
 
 class EmbeddingBatch:
@@ -141,7 +142,11 @@ class AzureOpenAIEmbeddingService(OpenAIEmbeddings):
         self.credential = credential
 
     async def create_client(self) -> AsyncOpenAI:
-        auth_args = {}
+        class AuthArgs(TypedDict, total=False):
+            api_key: str
+            azure_ad_token_provider: Callable[[], str | Awaitable[str]]
+
+        auth_args = AuthArgs()
         if isinstance(self.credential, AzureKeyCredential):
             auth_args["api_key"] = self.credential.key
         elif isinstance(self.credential, AsyncTokenCredential):

--- a/scripts/prepdocslib/embeddings.py
+++ b/scripts/prepdocslib/embeddings.py
@@ -144,7 +144,7 @@ class AzureOpenAIEmbeddingService(OpenAIEmbeddings):
     async def create_client(self) -> AsyncOpenAI:
         class AuthArgs(TypedDict, total=False):
             api_key: str
-            azure_ad_token_provider: Callable[[], str | Awaitable[str]]
+            azure_ad_token_provider: Callable[[], Union[str, Awaitable[str]]]
 
         auth_args = AuthArgs()
         if isinstance(self.credential, AzureKeyCredential):


### PR DESCRIPTION
## Purpose

Our prepdocs code was still using the old hack for AD authentication. This PR updates the code to use token_provider, the recommended way.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Run ./scripts/prepdocs.sh while using Azure default auth 