### PR TITLE
Change default temp to 0.3 for final chat completion call in chat approaches

### DIFF
--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -196,7 +196,7 @@ class ChatReadRetrieveReadApproach(ChatApproach):
             # Azure Open AI takes the deployment name as the model name
             model=self.chatgpt_deployment if self.chatgpt_deployment else self.chatgpt_model,
             messages=messages,
-            temperature=overrides.get("temperature", 0.7),
+            temperature=overrides.get("temperature", 0.3),
             max_tokens=response_token_limit,
             n=1,
             stream=should_stream,

--- a/app/backend/approaches/chatreadretrievereadvision.py
+++ b/app/backend/approaches/chatreadretrievereadvision.py
@@ -194,7 +194,7 @@ class ChatReadRetrieveReadVisionApproach(ChatApproach):
         chat_coroutine = self.openai_client.chat.completions.create(
             model=self.gpt4v_deployment if self.gpt4v_deployment else self.gpt4v_model,
             messages=messages,
-            temperature=overrides.get("temperature", 0.7),
+            temperature=overrides.get("temperature", 0.3),
             max_tokens=response_token_limit,
             n=1,
             stream=should_stream,


### PR DESCRIPTION
## Purpose

This pull request includes changes to the `run_until_final_call` function in two files: `app/backend/approaches/chatreadretrieveread.py` and `app/backend/approaches/chatreadretrievereadvision.py`. The changes involve adjusting the temperature parameter for the OpenAI chat completion function from 0.7 to 0.3. This will affect the randomness of the AI's responses, making them more deterministic and less random.

The ask approach already uses 0.3, so this makes chat match it.

The 0.3 did well in evaluations as compared to current baseline:

![Screenshot 2024-02-05 at 5 01 03 PM](https://github.com/Azure-Samples/azure-search-openai-demo/assets/297042/3f545c4b-b1ac-493b-b600-a21487555e8b)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe:
```

## How to Test

* Ran evaluation