### PR TITLE
Only output identity for non-free SKU

### DIFF
--- a/infra/core/search/search-services.bicep
+++ b/infra/core/search/search-services.bicep
@@ -62,4 +62,4 @@ resource search 'Microsoft.Search/searchServices@2021-04-01-preview' = {
 output id string = search.id
 output endpoint string = 'https://${name}.search.windows.net/'
 output name string = search.name
-output principalId string = search.identity.principalId
+output principalId string = (sku.name == 'free') ? '' : search.identity.principalId


### PR DESCRIPTION
## Purpose

fixes #1254 

This pull request includes a change in the `search-services.bicep` file. The change modifies the output of `principalId` to conditionally return an empty string when the `sku.name` is 'free', otherwise it returns `search.identity.principalId`.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Follow free deployment instructions
* Run azd up