### PR TITLE
Better conditional around searchservice principalId output

### DIFF
--- a/infra/core/search/search-services.bicep
+++ b/infra/core/search/search-services.bicep
@@ -36,14 +36,16 @@ param replicaCount int = 1
 ])
 param semanticSearch string = 'disabled'
 
+var searchIdentityProvider = (sku.name == 'free') ? null : {
+  type: 'SystemAssigned'
+}
+
 resource search 'Microsoft.Search/searchServices@2021-04-01-preview' = {
   name: name
   location: location
   tags: tags
   // The free tier does not support managed identity
-  identity: (sku.name == 'free') ? null : {
-    type: 'SystemAssigned'
-  }
+  identity: searchIdentityProvider
   properties: {
     authOptions: authOptions
     disableLocalAuth: disableLocalAuth
@@ -62,4 +64,4 @@ resource search 'Microsoft.Search/searchServices@2021-04-01-preview' = {
 output id string = search.id
 output endpoint string = 'https://${name}.search.windows.net/'
 output name string = search.name
-output principalId string = (sku.name == 'free') ? '' : search.identity.principalId
+output principalId string = !empty(searchIdentityProvider) ? search.identity.principalId : ''


### PR DESCRIPTION
## Purpose

I didn't like how non-DRY my last change was, so this PR DRYs it up.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  I ran azd provision from a free env and a non-free env