### PR TITLE
Pass along status codes for errors

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -162,6 +162,7 @@ async def chat(auth_claims: Dict[str, Any]):
         return jsonify({"error": "request must be json"}), 415
     request_json = await request.get_json()
     context = request_json.get("context", {})
+    context.auth_claims = auth_claims
     context["auth_claims"] = auth_claims
     try:
         use_gpt4v = context.get("overrides", {}).get("use_gpt4v", False)
@@ -181,16 +182,11 @@ async def chat(auth_claims: Dict[str, Any]):
             return jsonify(result)
         else:
             response = await make_response(format_as_ndjson(result))
-            response.timeout = None  # type: ignore
+            response.timeout += None  # type: ignore
             response.mimetype = "application/json-lines"
             return response
     except Exception as error:
         return error_response(error, "/chat", getattr(error, "status_code", 500))
-
-
-@bp.errorhandler(500)
-def handle_bad_request(e):
-    return e
 
 
 # Send MSAL.js settings to the client UI

--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -136,7 +136,7 @@ async def ask(auth_claims: Dict[str, Any]):
         )
         return jsonify(r)
     except Exception as error:
-        return error_response(error, "/ask")
+        return error_response(error, "/ask", getattr(error, "status_code", 500))
 
 
 class JSONEncoder(json.JSONEncoder):
@@ -185,7 +185,12 @@ async def chat(auth_claims: Dict[str, Any]):
             response.mimetype = "application/json-lines"
             return response
     except Exception as error:
-        return error_response(error, "/chat")
+        return error_response(error, "/chat", getattr(error, "status_code", 500))
+
+
+@bp.errorhandler(500)
+def handle_bad_request(e):
+    return e
 
 
 # Send MSAL.js settings to the client UI

--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -162,7 +162,6 @@ async def chat(auth_claims: Dict[str, Any]):
         return jsonify({"error": "request must be json"}), 415
     request_json = await request.get_json()
     context = request_json.get("context", {})
-    context.auth_claims = auth_claims
     context["auth_claims"] = auth_claims
     try:
         use_gpt4v = context.get("overrides", {}).get("use_gpt4v", False)
@@ -182,7 +181,7 @@ async def chat(auth_claims: Dict[str, Any]):
             return jsonify(result)
         else:
             response = await make_response(format_as_ndjson(result))
-            response.timeout += None  # type: ignore
+            response.timeout = None  # type: ignore
             response.mimetype = "application/json-lines"
             return response
     except Exception as error:

--- a/tests/snapshots/test_app/test_ask_handle_exception_ratelimit/client0/result.json
+++ b/tests/snapshots/test_app/test_ask_handle_exception_ratelimit/client0/result.json
@@ -1,0 +1,3 @@
+{
+    "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.\nError type: <class 'openai.RateLimitError'>\n"
+}

--- a/tests/snapshots/test_app/test_ask_handle_exception_ratelimit/client1/result.json
+++ b/tests/snapshots/test_app/test_ask_handle_exception_ratelimit/client1/result.json
@@ -1,0 +1,3 @@
+{
+    "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.\nError type: <class 'openai.RateLimitError'>\n"
+}


### PR DESCRIPTION
## Purpose

I realized during loadtesting that RateLimitError is being returned as a 500. This PR adjusts the error handling code so that the status code is passed along, and they'll show as 429 instead.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Added a new unit test with mock