### PR TITLE
Demonstration of using tools to do more specialized queries 

### DIFF
--- a/app/backend/approaches/approach.py
+++ b/app/backend/approaches/approach.py
@@ -121,6 +121,11 @@ class Approach(ABC):
         use_semantic_captions: bool,
     ) -> List[Document]:
         # Use semantic ranker if requested and if retrieval mode is text or hybrid (vectors + text)
+
+        if query_text.startswith("filename:"):
+            filter = f"sourcepage eq '{query_text[9:]}'"
+            results = await self.search_client.search("", filter=filter, top=top)
+            print(f"searching by filename: {query_text[9:]}")
         if use_semantic_ranker and query_text:
             results = await self.search_client.search(
                 search_text=query_text,

--- a/app/backend/approaches/chatapproach.py
+++ b/app/backend/approaches/chatapproach.py
@@ -81,6 +81,10 @@ class ChatApproach(Approach, ABC):
                     search_query = arg.get("search_query", self.NO_RESPONSE)
                     if search_query != self.NO_RESPONSE:
                         return search_query
+                if function.name == "search_by_filename":
+                    arg = json.loads(function.arguments)
+                    filename = arg.get("filename", "")
+                    return f"filename:{filename}"
         elif query_text := response_message.content:
             if query_text.strip() != self.NO_RESPONSE:
                 return query_text

--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -112,7 +112,24 @@ class ChatReadRetrieveReadApproach(ChatApproach):
                         "required": ["search_query"],
                     },
                 },
-            }
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "search_by_filename",
+                    "description": "Retrieve a specific filename from the Azure AI Search index",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "filename": {
+                                "type": "string",
+                                "description": "The filename, like 'PerksPlus.pdf'",
+                            }
+                        },
+                        "required": ["filename"],
+                    },
+                },
+            },
         ]
 
         # STEP 1: Generate an optimized keyword search query based on the chat history and the last question


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->


## Does this introduce a breaking change?

When developers merge from main and runa## Purpose

This is an example PR, not intended for merging, demonstrating the usage of Chat Completion API function calling in order to perform a more specific search query. In this case, I defined a "search_by_filename" function, and the model knows to call that when I enter a question like "Summarize the document named converting-html-pages-to-pdfs-with.html". I then pass that along to the search function and turn it into a filter.

This sort of approach could also work for searching by additional fields that are in an index. For example, if a field stores the timestamp of a document, you could search for documents created in a certain time period, by adding an appropriate function and filter condition.

Screenshots:

![Screenshot 2024-02-28 at 3 57 10 PM](https://github.com/Azure-Samples/azure-search-openai-demo/assets/297042/4f17f8f8-65e6-408a-99bf-0d9efb244053)

![Screenshot 2024-02-28 at 3 57 22 PM](https://github.com/Azure-Samples/azure-search-openai-demo/assets/297042/fb36f31f-d83d-4459-8871-8ff123f63578)

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](../CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [X] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.

Not done since not currently intending to merge this, just want to point developers to it. the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[ ] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[ ] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](../CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
