### PR TITLE
Update productionizing.md with link to search service size guide

### DIFF
--- a/docs/productionizing.md
+++ b/docs/productionizing.md
@@ -42,7 +42,7 @@ the number of replicas by changing `replicaCount` in `infra/core/search/search-s
 or manually scaling it from the Azure Portal.
 
 The search service can handle fairly large indexes, but it does have per-SKU limits on storage sizes, maximum vector dimensions, etc.
-See the [service limits document](https://learn.microsoft.com/en-us/azure/search/search-limits-quotas-capacity) for more details.
+See the [service limits document](https://learn.microsoft.com/azure/search/search-limits-quotas-capacity) for more details.
 
 ### Azure App Service
 

--- a/docs/productionizing.md
+++ b/docs/productionizing.md
@@ -41,6 +41,9 @@ If you see errors about search service capacity being exceeded, you may find it 
 the number of replicas by changing `replicaCount` in `infra/core/search/search-services.bicep`
 or manually scaling it from the Azure Portal.
 
+The search service can handle fairly large indexes, but it does have per-SKU limits on storage sizes, maximum vector dimensions, etc.
+See the [service limits document](https://learn.microsoft.com/en-us/azure/search/search-limits-quotas-capacity) for more details.
+
 ### Azure App Service
 
 The default app service plan uses the `Basic` SKU with 1 CPU core and 1.75 GB RAM.


### PR DESCRIPTION
## Purpose

Adds a link to the search service size guide, for customers wondering about productionizing their index.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](../CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.

Not relevant for docs.