### PR TITLE
Restrict GitHub workflows run

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches: [ main ]
     paths:
-      - "infra/frontend/**"
+      - "app/frontend/**"
 
 jobs:
     prettier:

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -3,8 +3,12 @@ name: Frontend linting
 on:
   push:
     branches: [ main ]
+    paths:
+      - "app/frontend/**"
   pull_request:
     branches: [ main ]
+    paths:
+      - "infra/frontend/**"
 
 jobs:
     prettier:

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -10,7 +10,7 @@ on:
       - ".github/**"
   pull_request:
     branches: [ main ]
-    paths:
+    paths-ignore:
       - "**.md"
       - ".azdo/**"
       - ".devcontainer/**"

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -3,8 +3,12 @@ name: Python check
 on:
   push:
     branches: [ main ]
+    paths:
+      - "**.py"
   pull_request:
     branches: [ main ]
+    paths:
+      - "**.py"
   workflow_call:
 
 jobs:

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -3,12 +3,18 @@ name: Python check
 on:
   push:
     branches: [ main ]
-    paths:
-      - "**.py"
+    paths-ignore:
+      - "**.md"
+      - ".azdo/**"
+      - ".devcontainer/**"
+      - ".github/**"
   pull_request:
     branches: [ main ]
     paths:
-      - "**.py"
+      - "**.md"
+      - ".azdo/**"
+      - ".devcontainer/**"
+      - ".github/**"
   workflow_call:
 
 jobs:


### PR DESCRIPTION
## Purpose
Fix #1356 
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- restrict frontend workflow to changes in the frontend folder
- restrict python workflow runs to changes in python files


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](../CONTRIBUTING.md#submit-pr) for more details.

- [X] The current tests all pass (`python -m pytest`).
- [X] I added tests that prove my fix is effective or that my feature works
- [X] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [X] I ran `python -m mypy` to check for type errors
- [X] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
