### PR TITLE
Add minimum score criteria for AI search results

### DIFF
--- a/app/backend/approaches/approach.py
+++ b/app/backend/approaches/approach.py
@@ -165,10 +165,11 @@ class Approach(ABC):
                 )
 
             qualified_documents = [
-                doc for doc in documents
+                doc
+                for doc in documents
                 if (
-                    (doc.score or 0) >= (minimum_search_score or 0) and
-                    (doc.reranker_score or 0) >= (minimum_reranker_score or 0)
+                    (doc.score or 0) >= (minimum_search_score or 0)
+                    and (doc.reranker_score or 0) >= (minimum_reranker_score or 0)
                 )
             ]
 

--- a/app/backend/approaches/approach.py
+++ b/app/backend/approaches/approach.py
@@ -123,8 +123,8 @@ class Approach(ABC):
         vectors: List[VectorQuery],
         use_semantic_ranker: bool,
         use_semantic_captions: bool,
-        min_search_score: Optional[float],
-        min_reranker_score: Optional[float],
+        minimum_search_score: Optional[float],
+        minimum_reranker_score: Optional[float],
     ) -> List[Document]:
         # Use semantic ranker if requested and if retrieval mode is text or hybrid (vectors + text)
         if use_semantic_ranker and query_text:
@@ -159,14 +159,17 @@ class Approach(ABC):
                         oids=document.get("oids"),
                         groups=document.get("groups"),
                         captions=cast(List[QueryCaptionResult], document.get("@search.captions")),
-                        score=document.get("@search.score", 0.0),
-                        reranker_score=document.get("@search.reranker_score", 0.0),
+                        score=document.get("@search.score"),
+                        reranker_score=document.get("@search.reranker_score"),
                     )
                 )
 
             qualified_documents = [
                 doc for doc in documents
-                if doc.search_score >= min_search_score and doc.reranker_score >= min_reranker_score
+                if (
+                    (doc.score or 0) >= (minimum_search_score or 0) and
+                    (doc.reranker_score or 0) >= (minimum_reranker_score or 0)
+                )
             ]
 
         return qualified_documents

--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -90,7 +90,7 @@ class ChatReadRetrieveReadApproach(ChatApproach):
         use_semantic_captions = True if overrides.get("semantic_captions") and has_text else False
         top = overrides.get("top", 3)
         minimum_search_score = overrides.get("minimum_search_score", 0.0)
-        minimum_reranker_score = overrides.get("minimum_reranker_score", 0.0)        
+        minimum_reranker_score = overrides.get("minimum_reranker_score", 0.0)
 
         filter = self.build_filter(overrides, auth_claims)
         use_semantic_ranker = True if overrides.get("semantic_ranker") and has_text else False
@@ -152,7 +152,16 @@ class ChatReadRetrieveReadApproach(ChatApproach):
         if not has_text:
             query_text = None
 
-        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions, minimum_search_score, minimum_reranker_score)
+        results = await self.search(
+            top,
+            query_text,
+            filter,
+            vectors,
+            use_semantic_ranker,
+            use_semantic_captions,
+            minimum_search_score,
+            minimum_reranker_score,
+        )
 
         sources_content = self.get_sources_content(results, use_semantic_captions, use_image_citation=False)
         content = "\n".join(sources_content)

--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -89,6 +89,9 @@ class ChatReadRetrieveReadApproach(ChatApproach):
         has_vector = overrides.get("retrieval_mode") in ["vectors", "hybrid", None]
         use_semantic_captions = True if overrides.get("semantic_captions") and has_text else False
         top = overrides.get("top", 3)
+        min_search_score = overrides.get("min_search_score", 0.0)
+        min_reranker_score = overrides.get("min_reranker_score", 0.0)        
+
         filter = self.build_filter(overrides, auth_claims)
         use_semantic_ranker = True if overrides.get("semantic_ranker") and has_text else False
 
@@ -149,7 +152,7 @@ class ChatReadRetrieveReadApproach(ChatApproach):
         if not has_text:
             query_text = None
 
-        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions)
+        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions, min_search_score, min_reranker_score)
 
         sources_content = self.get_sources_content(results, use_semantic_captions, use_image_citation=False)
         content = "\n".join(sources_content)

--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -89,8 +89,8 @@ class ChatReadRetrieveReadApproach(ChatApproach):
         has_vector = overrides.get("retrieval_mode") in ["vectors", "hybrid", None]
         use_semantic_captions = True if overrides.get("semantic_captions") and has_text else False
         top = overrides.get("top", 3)
-        min_search_score = overrides.get("min_search_score", 0.0)
-        min_reranker_score = overrides.get("min_reranker_score", 0.0)        
+        minimum_search_score = overrides.get("minimum_search_score", 0.0)
+        minimum_reranker_score = overrides.get("minimum_reranker_score", 0.0)        
 
         filter = self.build_filter(overrides, auth_claims)
         use_semantic_ranker = True if overrides.get("semantic_ranker") and has_text else False
@@ -152,7 +152,7 @@ class ChatReadRetrieveReadApproach(ChatApproach):
         if not has_text:
             query_text = None
 
-        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions, min_search_score, min_reranker_score)
+        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions, minimum_search_score, minimum_reranker_score)
 
         sources_content = self.get_sources_content(results, use_semantic_captions, use_image_citation=False)
         content = "\n".join(sources_content)

--- a/app/backend/approaches/chatreadretrievereadvision.py
+++ b/app/backend/approaches/chatreadretrievereadvision.py
@@ -87,8 +87,8 @@ class ChatReadRetrieveReadVisionApproach(ChatApproach):
         vector_fields = overrides.get("vector_fields", ["embedding"])
         use_semantic_captions = True if overrides.get("semantic_captions") and has_text else False
         top = overrides.get("top", 3)
-        min_search_score = overrides.get("min_search_score", 0.0)
-        min_reranker_score = overrides.get("min_reranker_score", 0.0)      
+        minimum_search_score = overrides.get("minimum_search_score", 0.0)
+        minimum_reranker_score = overrides.get("minimum_reranker_score", 0.0)      
         filter = self.build_filter(overrides, auth_claims)
         use_semantic_ranker = True if overrides.get("semantic_ranker") and has_text else False
 
@@ -136,7 +136,7 @@ class ChatReadRetrieveReadVisionApproach(ChatApproach):
         if not has_text:
             query_text = None
 
-        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions, min_search_score, min_reranker_score)
+        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions, minimum_search_score, minimum_reranker_score)
         sources_content = self.get_sources_content(results, use_semantic_captions, use_image_citation=True)
         content = "\n".join(sources_content)
 

--- a/app/backend/approaches/chatreadretrievereadvision.py
+++ b/app/backend/approaches/chatreadretrievereadvision.py
@@ -87,6 +87,8 @@ class ChatReadRetrieveReadVisionApproach(ChatApproach):
         vector_fields = overrides.get("vector_fields", ["embedding"])
         use_semantic_captions = True if overrides.get("semantic_captions") and has_text else False
         top = overrides.get("top", 3)
+        min_search_score = overrides.get("min_search_score", 0.0)
+        min_reranker_score = overrides.get("min_reranker_score", 0.0)      
         filter = self.build_filter(overrides, auth_claims)
         use_semantic_ranker = True if overrides.get("semantic_ranker") and has_text else False
 
@@ -134,7 +136,7 @@ class ChatReadRetrieveReadVisionApproach(ChatApproach):
         if not has_text:
             query_text = None
 
-        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions)
+        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions, min_search_score, min_reranker_score)
         sources_content = self.get_sources_content(results, use_semantic_captions, use_image_citation=True)
         content = "\n".join(sources_content)
 

--- a/app/backend/approaches/chatreadretrievereadvision.py
+++ b/app/backend/approaches/chatreadretrievereadvision.py
@@ -88,7 +88,7 @@ class ChatReadRetrieveReadVisionApproach(ChatApproach):
         use_semantic_captions = True if overrides.get("semantic_captions") and has_text else False
         top = overrides.get("top", 3)
         minimum_search_score = overrides.get("minimum_search_score", 0.0)
-        minimum_reranker_score = overrides.get("minimum_reranker_score", 0.0)      
+        minimum_reranker_score = overrides.get("minimum_reranker_score", 0.0)
         filter = self.build_filter(overrides, auth_claims)
         use_semantic_ranker = True if overrides.get("semantic_ranker") and has_text else False
 
@@ -136,7 +136,16 @@ class ChatReadRetrieveReadVisionApproach(ChatApproach):
         if not has_text:
             query_text = None
 
-        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions, minimum_search_score, minimum_reranker_score)
+        results = await self.search(
+            top,
+            query_text,
+            filter,
+            vectors,
+            use_semantic_ranker,
+            use_semantic_captions,
+            minimum_search_score,
+            minimum_reranker_score,
+        )
         sources_content = self.get_sources_content(results, use_semantic_captions, use_image_citation=True)
         content = "\n".join(sources_content)
 

--- a/app/backend/approaches/retrievethenread.py
+++ b/app/backend/approaches/retrievethenread.py
@@ -87,7 +87,7 @@ info4.pdf: In-network institutions include Overlake, Swedish and others in the r
         use_semantic_captions = True if overrides.get("semantic_captions") and has_text else False
         top = overrides.get("top", 3)
         minimum_search_score = overrides.get("minimum_search_score", 0.0)
-        minimum_reranker_score = overrides.get("minimum_reranker_score", 0.0)      
+        minimum_reranker_score = overrides.get("minimum_reranker_score", 0.0)
         filter = self.build_filter(overrides, auth_claims)
         # If retrieval mode includes vectors, compute an embedding for the query
         vectors: list[VectorQuery] = []
@@ -97,7 +97,16 @@ info4.pdf: In-network institutions include Overlake, Swedish and others in the r
         # Only keep the text query if the retrieval mode uses text, otherwise drop it
         query_text = q if has_text else None
 
-        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions, minimum_search_score, minimum_reranker_score)
+        results = await self.search(
+            top,
+            query_text,
+            filter,
+            vectors,
+            use_semantic_ranker,
+            use_semantic_captions,
+            minimum_search_score,
+            minimum_reranker_score,
+        )
 
         user_content = [q]
 

--- a/app/backend/approaches/retrievethenread.py
+++ b/app/backend/approaches/retrievethenread.py
@@ -86,6 +86,8 @@ info4.pdf: In-network institutions include Overlake, Swedish and others in the r
 
         use_semantic_captions = True if overrides.get("semantic_captions") and has_text else False
         top = overrides.get("top", 3)
+        min_search_score = overrides.get("min_search_score", 0.0)
+        min_reranker_score = overrides.get("min_reranker_score", 0.0)      
         filter = self.build_filter(overrides, auth_claims)
         # If retrieval mode includes vectors, compute an embedding for the query
         vectors: list[VectorQuery] = []
@@ -95,7 +97,7 @@ info4.pdf: In-network institutions include Overlake, Swedish and others in the r
         # Only keep the text query if the retrieval mode uses text, otherwise drop it
         query_text = q if has_text else None
 
-        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions)
+        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions, min_search_score, min_reranker_score)
 
         user_content = [q]
 

--- a/app/backend/approaches/retrievethenread.py
+++ b/app/backend/approaches/retrievethenread.py
@@ -86,8 +86,8 @@ info4.pdf: In-network institutions include Overlake, Swedish and others in the r
 
         use_semantic_captions = True if overrides.get("semantic_captions") and has_text else False
         top = overrides.get("top", 3)
-        min_search_score = overrides.get("min_search_score", 0.0)
-        min_reranker_score = overrides.get("min_reranker_score", 0.0)      
+        minimum_search_score = overrides.get("minimum_search_score", 0.0)
+        minimum_reranker_score = overrides.get("minimum_reranker_score", 0.0)      
         filter = self.build_filter(overrides, auth_claims)
         # If retrieval mode includes vectors, compute an embedding for the query
         vectors: list[VectorQuery] = []
@@ -97,7 +97,7 @@ info4.pdf: In-network institutions include Overlake, Swedish and others in the r
         # Only keep the text query if the retrieval mode uses text, otherwise drop it
         query_text = q if has_text else None
 
-        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions, min_search_score, min_reranker_score)
+        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions, minimum_search_score, minimum_reranker_score)
 
         user_content = [q]
 

--- a/app/backend/approaches/retrievethenreadvision.py
+++ b/app/backend/approaches/retrievethenreadvision.py
@@ -90,7 +90,7 @@ class RetrieveThenReadVisionApproach(Approach):
         use_semantic_captions = True if overrides.get("semantic_captions") and has_text else False
         top = overrides.get("top", 3)
         minimum_search_score = overrides.get("minimum_search_score", 0.0)
-        minimum_reranker_score = overrides.get("minimum_reranker_score", 0.0)      
+        minimum_reranker_score = overrides.get("minimum_reranker_score", 0.0)
         filter = self.build_filter(overrides, auth_claims)
         use_semantic_ranker = overrides.get("semantic_ranker") and has_text
 
@@ -109,7 +109,16 @@ class RetrieveThenReadVisionApproach(Approach):
         # Only keep the text query if the retrieval mode uses text, otherwise drop it
         query_text = q if has_text else None
 
-        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions, minimum_search_score, minimum_reranker_score)
+        results = await self.search(
+            top,
+            query_text,
+            filter,
+            vectors,
+            use_semantic_ranker,
+            use_semantic_captions,
+            minimum_search_score,
+            minimum_reranker_score,
+        )
 
         image_list: list[ChatCompletionContentPartImageParam] = []
         user_content: list[ChatCompletionContentPartParam] = [{"text": q, "type": "text"}]

--- a/app/backend/approaches/retrievethenreadvision.py
+++ b/app/backend/approaches/retrievethenreadvision.py
@@ -89,8 +89,8 @@ class RetrieveThenReadVisionApproach(Approach):
 
         use_semantic_captions = True if overrides.get("semantic_captions") and has_text else False
         top = overrides.get("top", 3)
-        min_search_score = overrides.get("min_search_score", 0.0)
-        min_reranker_score = overrides.get("min_reranker_score", 0.0)      
+        minimum_search_score = overrides.get("minimum_search_score", 0.0)
+        minimum_reranker_score = overrides.get("minimum_reranker_score", 0.0)      
         filter = self.build_filter(overrides, auth_claims)
         use_semantic_ranker = overrides.get("semantic_ranker") and has_text
 
@@ -109,7 +109,7 @@ class RetrieveThenReadVisionApproach(Approach):
         # Only keep the text query if the retrieval mode uses text, otherwise drop it
         query_text = q if has_text else None
 
-        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions, min_search_score, min_reranker_score)
+        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions, minimum_search_score, minimum_reranker_score)
 
         image_list: list[ChatCompletionContentPartImageParam] = []
         user_content: list[ChatCompletionContentPartParam] = [{"text": q, "type": "text"}]

--- a/app/backend/approaches/retrievethenreadvision.py
+++ b/app/backend/approaches/retrievethenreadvision.py
@@ -89,6 +89,8 @@ class RetrieveThenReadVisionApproach(Approach):
 
         use_semantic_captions = True if overrides.get("semantic_captions") and has_text else False
         top = overrides.get("top", 3)
+        min_search_score = overrides.get("min_search_score", 0.0)
+        min_reranker_score = overrides.get("min_reranker_score", 0.0)      
         filter = self.build_filter(overrides, auth_claims)
         use_semantic_ranker = overrides.get("semantic_ranker") and has_text
 
@@ -107,7 +109,7 @@ class RetrieveThenReadVisionApproach(Approach):
         # Only keep the text query if the retrieval mode uses text, otherwise drop it
         query_text = q if has_text else None
 
-        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions)
+        results = await self.search(top, query_text, filter, vectors, use_semantic_ranker, use_semantic_captions, min_search_score, min_reranker_score)
 
         image_list: list[ChatCompletionContentPartImageParam] = []
         user_content: list[ChatCompletionContentPartParam] = [{"text": q, "type": "text"}]

--- a/app/frontend/src/api/models.ts
+++ b/app/frontend/src/api/models.ts
@@ -23,6 +23,8 @@ export type ChatAppRequestOverrides = {
     exclude_category?: string;
     top?: number;
     temperature?: number;
+    min_search_score?: number;
+    min_reranker_score?: number;
     prompt_template?: string;
     prompt_template_prefix?: string;
     prompt_template_suffix?: string;

--- a/app/frontend/src/api/models.ts
+++ b/app/frontend/src/api/models.ts
@@ -23,8 +23,8 @@ export type ChatAppRequestOverrides = {
     exclude_category?: string;
     top?: number;
     temperature?: number;
-    min_search_score?: number;
-    min_reranker_score?: number;
+    minimum_search_score?: number;
+    minimum_reranker_score?: number;
     prompt_template?: string;
     prompt_template_prefix?: string;
     prompt_template_suffix?: string;

--- a/app/frontend/src/pages/ask/Ask.module.css
+++ b/app/frontend/src/pages/ask/Ask.module.css
@@ -56,6 +56,8 @@
 }
 
 .askSettingsSeparator {
+    display: flex;
+    flex-direction: column;
     margin-top: 15px;
 }
 

--- a/app/frontend/src/pages/ask/Ask.tsx
+++ b/app/frontend/src/pages/ask/Ask.tsx
@@ -22,6 +22,8 @@ export function Component(): JSX.Element {
     const [promptTemplatePrefix, setPromptTemplatePrefix] = useState<string>("");
     const [promptTemplateSuffix, setPromptTemplateSuffix] = useState<string>("");
     const [temperature, setTemperature] = useState<number>(0.3);
+    const [minRerankerScore, setMinRerankerScore] = useState<number>(0);
+    const [minSearchScore, setMinSearchScore] = useState<number>(0);
     const [retrievalMode, setRetrievalMode] = useState<RetrievalMode>(RetrievalMode.Hybrid);
     const [retrieveCount, setRetrieveCount] = useState<number>(3);
     const [useSemanticRanker, setUseSemanticRanker] = useState<boolean>(true);
@@ -92,6 +94,8 @@ export function Component(): JSX.Element {
                         exclude_category: excludeCategory.length === 0 ? undefined : excludeCategory,
                         top: retrieveCount,
                         temperature: temperature,
+                        min_reranker_score: minRerankerScore,
+                        min_search_score: minSearchScore,
                         retrieval_mode: retrievalMode,
                         semantic_ranker: useSemanticRanker,
                         semantic_captions: useSemanticCaptions,
@@ -132,6 +136,22 @@ export function Component(): JSX.Element {
         event?: React.MouseEvent | React.TouchEvent | MouseEvent | TouchEvent | React.KeyboardEvent
     ) => {
         setTemperature(newValue);
+    };
+
+    const onMinSearchScoreChange = (
+        newValue: number,
+        range?: [number, number],
+        event?: React.MouseEvent | React.TouchEvent | MouseEvent | TouchEvent | React.KeyboardEvent
+    ) => {
+        setMinSearchScore(newValue);
+    };
+
+    const onMinRerankerScoreChange = (
+        newValue: number,
+        range?: [number, number],
+        event?: React.MouseEvent | React.TouchEvent | MouseEvent | TouchEvent | React.KeyboardEvent
+    ) => {
+        setMinRerankerScore(newValue);
     };
 
     const onRetrieveCountChange = (_ev?: React.SyntheticEvent<HTMLElement, Event>, newValue?: string) => {
@@ -255,6 +275,30 @@ export function Component(): JSX.Element {
                     step={0.1}
                     defaultValue={temperature}
                     onChange={onTemperatureChange}
+                    showValue
+                    snapToStep
+                />
+
+                <Slider
+                    className={styles.chatSettingsSeparator}
+                    label="Min Search Score"
+                    min={0}
+                    max={1}
+                    step={0.1}
+                    defaultValue={minSearchScore}
+                    onChange={onMinSearchScoreChange}
+                    showValue
+                    snapToStep
+                />
+
+                <Slider
+                    className={styles.chatSettingsSeparator}
+                    label="Min Reranker Score"
+                    min={1}
+                    max={4}
+                    step={0.1}
+                    defaultValue={minRerankerScore}
+                    onChange={onMinRerankerScoreChange}
                     showValue
                     snapToStep
                 />

--- a/app/frontend/src/pages/ask/Ask.tsx
+++ b/app/frontend/src/pages/ask/Ask.tsx
@@ -22,8 +22,8 @@ export function Component(): JSX.Element {
     const [promptTemplatePrefix, setPromptTemplatePrefix] = useState<string>("");
     const [promptTemplateSuffix, setPromptTemplateSuffix] = useState<string>("");
     const [temperature, setTemperature] = useState<number>(0.3);
-    const [minRerankerScore, setMinRerankerScore] = useState<number>(0);
-    const [minSearchScore, setMinSearchScore] = useState<number>(0);
+    const [minimumRerankerScore, setMinimumRerankerScore] = useState<number>(0);
+    const [minimumSearchScore, setMinimumSearchScore] = useState<number>(0);
     const [retrievalMode, setRetrievalMode] = useState<RetrievalMode>(RetrievalMode.Hybrid);
     const [retrieveCount, setRetrieveCount] = useState<number>(3);
     const [useSemanticRanker, setUseSemanticRanker] = useState<boolean>(true);
@@ -94,8 +94,8 @@ export function Component(): JSX.Element {
                         exclude_category: excludeCategory.length === 0 ? undefined : excludeCategory,
                         top: retrieveCount,
                         temperature: temperature,
-                        min_reranker_score: minRerankerScore,
-                        min_search_score: minSearchScore,
+                        minimum_reranker_score: minimumRerankerScore,
+                        minimum_search_score: minimumSearchScore,
                         retrieval_mode: retrievalMode,
                         semantic_ranker: useSemanticRanker,
                         semantic_captions: useSemanticCaptions,
@@ -138,22 +138,13 @@ export function Component(): JSX.Element {
         setTemperature(newValue);
     };
 
-    const onMinSearchScoreChange = (
-        newValue: number,
-        range?: [number, number],
-        event?: React.MouseEvent | React.TouchEvent | MouseEvent | TouchEvent | React.KeyboardEvent
-    ) => {
-        setMinSearchScore(newValue);
+    const onMinimumSearchScoreChange = (_ev?: React.SyntheticEvent<HTMLElement, Event>, newValue?: string) => {
+        setMinimumSearchScore(parseInt(newValue || "0"));
     };
 
-    const onMinRerankerScoreChange = (
-        newValue: number,
-        range?: [number, number],
-        event?: React.MouseEvent | React.TouchEvent | MouseEvent | TouchEvent | React.KeyboardEvent
-    ) => {
-        setMinRerankerScore(newValue);
+    const onMinimumRerankerScoreChange = (_ev?: React.SyntheticEvent<HTMLElement, Event>, newValue?: string) => {
+        setMinimumRerankerScore(parseInt(newValue || "0"));
     };
-
     const onRetrieveCountChange = (_ev?: React.SyntheticEvent<HTMLElement, Event>, newValue?: string) => {
         setRetrieveCount(parseInt(newValue || "3"));
     };
@@ -279,28 +270,23 @@ export function Component(): JSX.Element {
                     snapToStep
                 />
 
-                <Slider
-                    className={styles.chatSettingsSeparator}
-                    label="Min Search Score"
+                <SpinButton
+                    className={styles.askSettingsSeparator}
+                    label="Minimum search score"
                     min={0}
-                    max={1}
-                    step={0.1}
-                    defaultValue={minSearchScore}
-                    onChange={onMinSearchScoreChange}
-                    showValue
-                    snapToStep
+                    step={0.01}
+                    defaultValue={minimumSearchScore.toString()}
+                    onChange={onMinimumSearchScoreChange}
                 />
 
-                <Slider
-                    className={styles.chatSettingsSeparator}
-                    label="Min Reranker Score"
+                <SpinButton
+                    className={styles.askSettingsSeparator}
+                    label="Minimum reranker score"
                     min={1}
                     max={4}
                     step={0.1}
-                    defaultValue={minRerankerScore}
-                    onChange={onMinRerankerScoreChange}
-                    showValue
-                    snapToStep
+                    defaultValue={minimumRerankerScore.toString()}
+                    onChange={onMinimumRerankerScoreChange}
                 />
 
                 <SpinButton

--- a/app/frontend/src/pages/ask/Ask.tsx
+++ b/app/frontend/src/pages/ask/Ask.tsx
@@ -139,11 +139,11 @@ export function Component(): JSX.Element {
     };
 
     const onMinimumSearchScoreChange = (_ev?: React.SyntheticEvent<HTMLElement, Event>, newValue?: string) => {
-        setMinimumSearchScore(parseInt(newValue || "0"));
+        setMinimumSearchScore(parseFloat(newValue || "0"));
     };
 
     const onMinimumRerankerScoreChange = (_ev?: React.SyntheticEvent<HTMLElement, Event>, newValue?: string) => {
-        setMinimumRerankerScore(parseInt(newValue || "0"));
+        setMinimumRerankerScore(parseFloat(newValue || "0"));
     };
     const onRetrieveCountChange = (_ev?: React.SyntheticEvent<HTMLElement, Event>, newValue?: string) => {
         setRetrieveCount(parseInt(newValue || "3"));

--- a/app/frontend/src/pages/chat/Chat.module.css
+++ b/app/frontend/src/pages/chat/Chat.module.css
@@ -97,6 +97,8 @@
 }
 
 .chatSettingsSeparator {
+    display: flex;
+    flex-direction: column;
     margin-top: 15px;
 }
 

--- a/app/frontend/src/pages/chat/Chat.tsx
+++ b/app/frontend/src/pages/chat/Chat.tsx
@@ -406,7 +406,7 @@ const Chat = () => {
                     />
 
                     <SpinButton
-                        className={styles.askSettingsSeparator}
+                        className={styles.chatSettingsSeparator}
                         label="Minimum search score"
                         min={0}
                         step={0.01}
@@ -415,7 +415,7 @@ const Chat = () => {
                     />
 
                     <SpinButton
-                        className={styles.askSettingsSeparator}
+                        className={styles.chatSettingsSeparator}
                         label="Minimum reranker score"
                         min={1}
                         max={4}

--- a/app/frontend/src/pages/chat/Chat.tsx
+++ b/app/frontend/src/pages/chat/Chat.tsx
@@ -149,6 +149,8 @@ const Chat = () => {
                         exclude_category: excludeCategory.length === 0 ? undefined : excludeCategory,
                         top: retrieveCount,
                         temperature: temperature,
+                        minimum_reranker_score: minimumRerankerScore,
+                        minimum_search_score: minimumSearchScore,
                         retrieval_mode: retrievalMode,
                         semantic_ranker: useSemanticRanker,
                         semantic_captions: useSemanticCaptions,
@@ -215,11 +217,11 @@ const Chat = () => {
     };
 
     const onMinimumSearchScoreChange = (_ev?: React.SyntheticEvent<HTMLElement, Event>, newValue?: string) => {
-        setMinimumSearchScore(parseInt(newValue || "0"));
+        setMinimumSearchScore(parseFloat(newValue || "0"));
     };
 
     const onMinimumRerankerScoreChange = (_ev?: React.SyntheticEvent<HTMLElement, Event>, newValue?: string) => {
-        setMinimumRerankerScore(parseInt(newValue || "0"));
+        setMinimumRerankerScore(parseFloat(newValue || "0"));
     };
 
     const onRetrieveCountChange = (_ev?: React.SyntheticEvent<HTMLElement, Event>, newValue?: string) => {

--- a/app/frontend/src/pages/chat/Chat.tsx
+++ b/app/frontend/src/pages/chat/Chat.tsx
@@ -33,6 +33,8 @@ const Chat = () => {
     const [isConfigPanelOpen, setIsConfigPanelOpen] = useState(false);
     const [promptTemplate, setPromptTemplate] = useState<string>("");
     const [temperature, setTemperature] = useState<number>(0.3);
+    const [minimumRerankerScore, setMinimumRerankerScore] = useState<number>(0);
+    const [minimumSearchScore, setMinimumSearchScore] = useState<number>(0);
     const [retrieveCount, setRetrieveCount] = useState<number>(3);
     const [retrievalMode, setRetrievalMode] = useState<RetrievalMode>(RetrievalMode.Hybrid);
     const [useSemanticRanker, setUseSemanticRanker] = useState<boolean>(true);
@@ -210,6 +212,14 @@ const Chat = () => {
         event?: React.MouseEvent | React.TouchEvent | MouseEvent | TouchEvent | React.KeyboardEvent
     ) => {
         setTemperature(newValue);
+    };
+
+    const onMinimumSearchScoreChange = (_ev?: React.SyntheticEvent<HTMLElement, Event>, newValue?: string) => {
+        setMinimumSearchScore(parseInt(newValue || "0"));
+    };
+
+    const onMinimumRerankerScoreChange = (_ev?: React.SyntheticEvent<HTMLElement, Event>, newValue?: string) => {
+        setMinimumRerankerScore(parseInt(newValue || "0"));
     };
 
     const onRetrieveCountChange = (_ev?: React.SyntheticEvent<HTMLElement, Event>, newValue?: string) => {
@@ -393,6 +403,25 @@ const Chat = () => {
                         onChange={onTemperatureChange}
                         showValue
                         snapToStep
+                    />
+
+                    <SpinButton
+                        className={styles.askSettingsSeparator}
+                        label="Minimum search score"
+                        min={0}
+                        step={0.01}
+                        defaultValue={minimumSearchScore.toString()}
+                        onChange={onMinimumSearchScoreChange}
+                    />
+
+                    <SpinButton
+                        className={styles.askSettingsSeparator}
+                        label="Minimum reranker score"
+                        min={1}
+                        max={4}
+                        step={0.1}
+                        defaultValue={minimumRerankerScore.toString()}
+                        onChange={onMinimumRerankerScoreChange}
                     />
 
                     <SpinButton

--- a/tests/test_chatapproach.py
+++ b/tests/test_chatapproach.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+from azure.core.credentials import AzureKeyCredential
 from azure.search.documents.aio import SearchClient
 from openai.types.chat import ChatCompletion
 
@@ -320,8 +321,22 @@ def test_get_messages_from_history_few_shots(chat_approach):
     ],
 )
 async def test_search_results_filtering_by_scores(
-    monkeypatch, chat_approach, minimum_search_score, minimum_reranker_score, expected_result_count
+    monkeypatch, minimum_search_score, minimum_reranker_score, expected_result_count
 ):
+
+    chat_approach = ChatReadRetrieveReadApproach(
+        search_client=SearchClient(endpoint="", index_name="", credential=AzureKeyCredential("")),
+        auth_helper=None,
+        openai_client=None,
+        chatgpt_model="gpt-35-turbo",
+        chatgpt_deployment="chat",
+        embedding_deployment="embeddings",
+        embedding_model="text-",
+        sourcepage_field="",
+        content_field="",
+        query_language="en-us",
+        query_speller="lexicon",
+    )
 
     monkeypatch.setattr(SearchClient, "search", mock_search)
 

--- a/tests/test_chatapproach.py
+++ b/tests/test_chatapproach.py
@@ -1,12 +1,12 @@
 import json
 
 import pytest
-from openai.types.chat import ChatCompletion
 from azure.search.documents.aio import SearchClient
+from openai.types.chat import ChatCompletion
+
 from approaches.chatreadretrieveread import ChatReadRetrieveReadApproach
-from .mocks import (
-    MockAsyncSearchResultsIterator
-)
+
+from .mocks import MockAsyncSearchResultsIterator
 
 
 async def mock_search(*args, **kwargs):
@@ -307,16 +307,21 @@ def test_get_messages_from_history_few_shots(chat_approach):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("minimum_search_score,minimum_reranker_score,expected_result_count", [
-    (0, 0, 1),
-    (0, 2, 1),
-    (0.03, 0, 1),
-    (0.03, 2, 1),
-    (1, 0, 0),
-    (0, 4, 0),
-    (1, 4, 0),
-])
-async def test_search_results_filtering_by_scores(monkeypatch, chat_approach, minimum_search_score, minimum_reranker_score, expected_result_count):
+@pytest.mark.parametrize(
+    "minimum_search_score,minimum_reranker_score,expected_result_count",
+    [
+        (0, 0, 1),
+        (0, 2, 1),
+        (0.03, 0, 1),
+        (0.03, 2, 1),
+        (1, 0, 0),
+        (0, 4, 0),
+        (1, 4, 0),
+    ],
+)
+async def test_search_results_filtering_by_scores(
+    monkeypatch, chat_approach, minimum_search_score, minimum_reranker_score, expected_result_count
+):
 
     monkeypatch.setattr(SearchClient, "search", mock_search)
 
@@ -331,4 +336,6 @@ async def test_search_results_filtering_by_scores(monkeypatch, chat_approach, mi
         minimum_reranker_score=minimum_reranker_score,
     )
 
-    assert len(filtered_results) == expected_result_count, f"Expected {expected_result_count} results with minimum_search_score={minimum_search_score} and minimum_reranker_score={minimum_reranker_score}"
+    assert (
+        len(filtered_results) == expected_result_count
+    ), f"Expected {expected_result_count} results with minimum_search_score={minimum_search_score} and minimum_reranker_score={minimum_reranker_score}"


### PR DESCRIPTION
## Purpose

A filtering mechanism based on minimum score criteria for documents. By setting a minimum value for both `search_score` and `reranker_score`. This aims to improve the relevance of documents sent to the AI, that only the most relevant information is sent for further processing.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[X] Yes
[ ] No
```

## Type of change

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](../CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [x] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
De