### PR TITLE
Ensure there are no zero-length sections for batch API

### DIFF
--- a/scripts/prepdocslib/textsplitter.py
+++ b/scripts/prepdocslib/textsplitter.py
@@ -101,7 +101,6 @@ class SentenceTextSplitter(TextSplitter):
         Recursively splits page by maximum number of tokens to better handle languages with higher token/word ratios.
         """
         tokens = bpe.encode(text)
-        assert text != ""
         if len(tokens) <= self.max_tokens_per_section:
             # Section is already within max tokens, return
             yield SplitPage(page_num=page_num, text=text)

--- a/scripts/prepdocslib/textsplitter.py
+++ b/scripts/prepdocslib/textsplitter.py
@@ -101,6 +101,7 @@ class SentenceTextSplitter(TextSplitter):
         Recursively splits page by maximum number of tokens to better handle languages with higher token/word ratios.
         """
         tokens = bpe.encode(text)
+        assert text != ""
         if len(tokens) <= self.max_tokens_per_section:
             # Section is already within max tokens, return
             yield SplitPage(page_num=page_num, text=text)
@@ -127,8 +128,10 @@ class SentenceTextSplitter(TextSplitter):
             else:
                 # Split page in half and call function again
                 # Overlap first and second halves by DEFAULT_OVERLAP_PERCENT%
-                first_half = text[: int(len(text) // (2.0 + (DEFAULT_OVERLAP_PERCENT / 100)))]
-                second_half = text[int(len(text) // (1.0 - (DEFAULT_OVERLAP_PERCENT / 100))) :]
+                middle = int(len(text) // 2)
+                overlap = int(len(text) * (DEFAULT_OVERLAP_PERCENT / 100))
+                first_half = text[: middle + overlap]
+                second_half = text[middle - overlap :]
             yield from self.split_page_by_max_tokens(page_num, first_half)
             yield from self.split_page_by_max_tokens(page_num, second_half)
 

--- a/tests/test_prepdocslib_textsplitter.py
+++ b/tests/test_prepdocslib_textsplitter.py
@@ -120,6 +120,7 @@ async def test_sentencetextsplitter_multilang(test_doc, tmp_path):
         # Verify the size of the sections
         token_lengths = []
         for section in sections:
+            assert section.split_page.text != ""
             assert len(section.split_page.text) <= (text_splitter.max_section_length * 1.2)
             # Verify the number of tokens is below 500
             token_lengths.append((len(bpe.encode(section.split_page.text)), len(section.split_page.text)))


### PR DESCRIPTION
## Purpose

Fixes a bug when a section doesn't contain _any_ sentence endings and isn't recursively split correctly. It was being split into one big section and one empty one.

Fixes #1415 

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[ ] No
```

## Type of change

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](../CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
