### PR TITLE
Added an instruction to Compile the JavaScript, required for pytest to pass.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,12 @@ Install the pre-commit hooks:
 pre-commit install
 ```
 
+Compile the JavaScript:
+
+```
+( cd ./app/frontend ; npm install ; npm run build )
+```
+
 ## <a name="unit-tests"></a> Running unit tests
 
 Run the tests:


### PR DESCRIPTION
## Purpose

Added an instruction to Compile the JavaScript. This is required for pytest tests to pass.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](../CONTRIBUTING.md#submit-pr) for more details.

- [X] The current tests all pass (`python -m pytest`).
- [X] I added tests that prove my fix is effective or that my feature works
- [X] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [X] I ran `python -m mypy` to check for type errors
- [X] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
