### PR TITLE
Add more tests to the splitter

### DIFF
--- a/scripts/prepdocslib/textsplitter.py
+++ b/scripts/prepdocslib/textsplitter.py
@@ -93,7 +93,7 @@ class SentenceTextSplitter(TextSplitter):
         self.max_section_length = DEFAULT_SECTION_LENGTH
         self.sentence_search_limit = 100
         self.max_tokens_per_section = max_tokens_per_section
-        self.section_overlap = self.max_section_length // DEFAULT_OVERLAP_PERCENT
+        self.section_overlap = self.max_section_length // DEFAULT_OVERLAP_PERCENT if DEFAULT_OVERLAP_PERCENT else 0
         self.has_image_embeddings = has_image_embeddings
 
     def split_page_by_max_tokens(self, page_num: int, text: str) -> Generator[SplitPage, None, None]:

--- a/tests/test_prepdocslib_textsplitter.py
+++ b/tests/test_prepdocslib_textsplitter.py
@@ -1,6 +1,7 @@
 import json
 import shutil
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import tiktoken
@@ -98,6 +99,10 @@ def pytest_generate_tests(metafunc):
 
 @pytest.mark.asyncio
 async def test_sentencetextsplitter_multilang(test_doc, tmp_path):
+    """
+    Tests all the documents in test-data which includes short stories in different languages and
+    scripts.
+    """
     text_splitter = SentenceTextSplitter(has_image_embeddings=False)
     bpe = tiktoken.encoding_for_model(ENCODING_MODEL)
     pdf_parser = LocalPdfParser()
@@ -165,3 +170,35 @@ an opportunity to discuss your goals and objectives for the upcoming year.
     assert "<table" in split_pages_with_table[0].text
     assert "<table" in split_pages_with_table[1].text
     assert split_pages_with_table[1].text != split_pages_without_table[1].text
+
+
+@pytest.mark.asyncio
+async def test_textsplitter_output_verify(test_doc, tmp_path):
+    """
+    Tests all the documents in test-data but without overlap. Verify that the output equals the input
+    """
+    with patch("scripts.prepdocslib.textsplitter.DEFAULT_OVERLAP_PERCENT", 0.0):
+        text_splitter = SentenceTextSplitter(has_image_embeddings=False)
+        bpe = tiktoken.encoding_for_model(ENCODING_MODEL)
+        pdf_parser = LocalPdfParser()
+
+        shutil.copy(str(test_doc.absolute()), tmp_path)
+
+        list_file_strategy = LocalListFileStrategy(path_pattern=str(tmp_path / "*"))
+        files = list_file_strategy.list()
+        processed = 0
+        async for file in files:
+            pages = [page async for page in pdf_parser.parse(content=file.content)]
+            assert pages
+            sections = [
+                Section(split_page, content=file, category="test category")
+                for split_page in text_splitter.split_pages(pages)
+            ]
+            assert sections
+            processed += 1
+
+            # Verify the merged sections equal the input text
+            original_content = "".join([page.text for page in pages])
+            merged_sections = "".join([section.split_page.text for section in sections])
+            assert merged_sections == original_content
+        assert processed == 1


### PR DESCRIPTION
## Purpose

Verify that the splitter will always yield the same content as the input

Noticed that if you set the overlap percent to 0 you get a DBZ error

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[ ] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[ ] No
```

## Type of change

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](../CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
