### PR TITLE
You need to run azd env new before you can run the startup scripts.

### DIFF
--- a/docs/localdev.md
+++ b/docs/localdev.md
@@ -4,7 +4,8 @@ You can only run locally **after** having successfully run the `azd up` command.
 
 1. Run `azd auth login`
 2. Change dir to `app`
-3. Run `./start.ps1` or `./start.sh` or run the "VS Code Task: Start App" to start the project locally.
+3. Run `azd env new`.
+4. Run `./start.ps1` or `./start.sh` or run the "VS Code Task: Start App" to start the project locally.
 
 ## Hot reloading frontend and backend files
 


### PR DESCRIPTION
## Purpose

The tutorial needed an extra step. You need to run "azd env new" to create the .env-file that is needed to run the scripts in step 4 (before, it was step 3). This will fix the tutorial for running the project locally. 


No breaking changes. 

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X ] No
```

## Does this require changes to learn.microsoft.com docs? - No

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[ X] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ X] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ X] The current tests all pass (`python -m pytest`).
- [ X] I added tests that prove my fix is effective or that my feature works
- [ X] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ X] I ran `python -m mypy` to check for type errors
- [ X] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
