### PR TITLE
Fix search secret name environment variable for free deploys

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -216,7 +216,7 @@ async def setup_clients():
     AZURE_STORAGE_CONTAINER = os.environ["AZURE_STORAGE_CONTAINER"]
     AZURE_SEARCH_SERVICE = os.environ["AZURE_SEARCH_SERVICE"]
     AZURE_SEARCH_INDEX = os.environ["AZURE_SEARCH_INDEX"]
-    SEARCH_SECRET_NAME = os.getenv("SEARCH_SECRET_NAME")
+    AZURE_SEARCH_SECRET_NAME = os.getenv("AZURE_SEARCH_SECRET_NAME")
     AZURE_KEY_VAULT_NAME = os.getenv("AZURE_KEY_VAULT_NAME")
     # Shared by all OpenAI deployments
     OPENAI_HOST = os.getenv("OPENAI_HOST", "azure")
@@ -264,7 +264,7 @@ async def setup_clients():
         key_vault_client = SecretClient(
             vault_url=f"https://{AZURE_KEY_VAULT_NAME}.vault.azure.net", credential=azure_credential
         )
-        search_key = SEARCH_SECRET_NAME and (await key_vault_client.get_secret(SEARCH_SECRET_NAME)).value
+        search_key = AZURE_SEARCH_SECRET_NAME and (await key_vault_client.get_secret(AZURE_SEARCH_SECRET_NAME)).value
         await key_vault_client.close()
 
     # Set up clients for AI Search and Storage

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -237,7 +237,7 @@ module backend 'core/host/appservice.bicep' = {
       AZURE_SEARCH_SERVICE: searchService.outputs.name
       AZURE_SEARCH_SEMANTIC_RANKER: actualSearchServiceSemanticRankerLevel
       AZURE_VISION_ENDPOINT: useGPT4V ? computerVision.outputs.endpoint : ''
-      SEARCH_SECRET_NAME: useSearchServiceKey ? searchServiceSecretName : ''
+      AZURE_SEARCH_SECRET_NAME: useSearchServiceKey ? searchServiceSecretName : ''
       AZURE_KEY_VAULT_NAME: useKeyVault ? keyVault.outputs.name : ''
       AZURE_SEARCH_QUERY_LANGUAGE: searchQueryLanguage
       AZURE_SEARCH_QUERY_SPELLER: searchQuerySpeller

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -114,7 +114,7 @@ async def test_app_config_for_client(client):
 async def test_app_visionkey_notfound(monkeypatch, minimal_env):
     monkeypatch.setenv("AZURE_KEY_VAULT_NAME", "my_key_vault")
     monkeypatch.setenv("VISION_SECRET_NAME", "")
-    monkeypatch.setenv("SEARCH_SECRET_NAME", "search-secret-name")
+    monkeypatch.setenv("AZURE_SEARCH_SECRET_NAME", "search-secret-name")
 
     async def get_secret(*args, **kwargs):
         if args[1] == "vision-secret-name":
@@ -132,7 +132,7 @@ async def test_app_visionkey_notfound(monkeypatch, minimal_env):
 async def test_app_searchkey_notfound(monkeypatch, minimal_env):
     monkeypatch.setenv("AZURE_KEY_VAULT_NAME", "my_key_vault")
     monkeypatch.setenv("VISION_SECRET_NAME", "vision-secret-name")
-    monkeypatch.setenv("SEARCH_SECRET_NAME", "")
+    monkeypatch.setenv("AZURE_SEARCH_SECRET_NAME", "")
 
     async def get_secret(*args, **kwargs):
         if args[1] == "search-secret-name":


### PR DESCRIPTION
## Purpose

I realized (from an internal bug report) that we were using two different env vars, SEARCH_SECRET_NAME and AZURE_SEARCH_SECRET_NAME. This PR fixes the code to always use AZURE_SEARCH_SECRET_NAME.


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [X] The current tests all pass (`python -m pytest`).
- [X] I added tests that prove my fix is effective or that my feature works
- [X] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [X] I ran `python -m mypy` to check for type errors
- [X] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
