### PR TITLE
Set public network access to deny and allow azure network access

### DIFF
--- a/infra/core/security/keyvault.bicep
+++ b/infra/core/security/keyvault.bicep
@@ -1,6 +1,19 @@
 metadata description = 'Creates an Azure Key Vault.'
 param name string
 param location string = resourceGroup().location
+
+// Allow public network access to Key Vault
+param allowPublicNetworkAccess bool = false
+
+// Allow all Azure services to bypass Key Vault network rules
+param allowAzureServicesAccess bool = true
+
+param networkAcls object = {
+  bypass: allowAzureServicesAccess ? 'AzureServices' : 'None'
+  defaultAction: allowPublicNetworkAccess ? 'Allow' : 'Deny'
+  ipRules: []
+  virtualNetworkRules: []
+}
 param tags object = {}
 
 param principalId string = ''
@@ -14,6 +27,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
     sku: { family: 'A', name: 'standard' }
     enablePurgeProtection: true
     enableSoftDelete: true
+    networkAcls: networkAcls
     accessPolicies: !empty(principalId) ? [
       {
         objectId: principalId


### PR DESCRIPTION
This is a breaking change since the old template would allow any public IP to try and connect to the deployed Keyvault environment..

https://microsoft.sharepoint.com/teams/AzureTenantBaseline2/SitePages/Key-Vault-must-have-public-access-disabled.aspx (Internal) reference on this security policy

## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[ ] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[ ] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
