### PR TITLE
Correct datalakepath argument in prepdocs.sh and prepdocs.ps1

### DIFF
--- a/scripts/prepdocs.ps1
+++ b/scripts/prepdocs.ps1
@@ -13,7 +13,7 @@ if ($env:AZURE_ADLS_GEN2_STORAGE_ACCOUNT) {
   $adlsGen2StorageAccountArg = "--datalakestorageaccount $env:AZURE_ADLS_GEN2_STORAGE_ACCOUNT"
   $adlsGen2FilesystemPathArg = ""
   if ($env:AZURE_ADLS_GEN2_FILESYSTEM_PATH) {
-    $adlsGen2FilesystemPathArg = "--datalakefilesystempath $env:AZURE_ADLS_GEN2_FILESYSTEM_PATH"
+    $adlsGen2FilesystemPathArg = "--datalakepath $env:AZURE_ADLS_GEN2_FILESYSTEM_PATH"
   }
   $adlsGen2FilesystemArg = ""
   if ($env:AZURE_ADLS_GEN2_FILESYSTEM) {

--- a/scripts/prepdocs.sh
+++ b/scripts/prepdocs.sh
@@ -8,7 +8,7 @@ if [ -n "$AZURE_ADLS_GEN2_STORAGE_ACCOUNT" ]; then
   adlsGen2StorageAccountArg="--datalakestorageaccount $AZURE_ADLS_GEN2_STORAGE_ACCOUNT"
   adlsGen2FilesystemPathArg=""
   if [ -n "$AZURE_ADLS_GEN2_FILESYSTEM_PATH" ]; then
-    adlsGen2FilesystemPathArg="--datalakefilesystempath $AZURE_ADLS_GEN2_FILESYSTEM_PATH"
+    adlsGen2FilesystemPathArg="--datalakepath $AZURE_ADLS_GEN2_FILESYSTEM_PATH"
   fi
   adlsGen2FilesystemArg=""
   if [ -n "$AZURE_ADLS_GEN2_FILESYSTEM" ]; then


### PR DESCRIPTION
## Purpose

Fixes #1477

I haven't tested myself, but it looks correct in terms of the args, and this fix worked for the reporter.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [X] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works - No tests for the shell scripts :(
- [X] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [X] I ran `python -m mypy` to check for type errors
- [X] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
