### PR TITLE
Add python-dotenv to eliminate error in Github CodeSpaces

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ playwright
 pytest-cov
 pytest-playwright
 pytest-snapshot
+python-dotenv
 pre-commit
 locust
 pip-tools


### PR DESCRIPTION
## Purpose

Currently, when I try to run this repo in CodeSpaces, I get an error saying 

` Error: there is no registered task type 'dotenv'. Did you miss installing an extension that provides a corresponding task provider? `

## Does this introduce a breaking change?

[ ] Yes
[X ] No


## Does this require changes to learn.microsoft.com docs?

```
[ ] Yes
[X ] No
```

## Type of change

```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
