### PR TITLE
Adds storageURL field to track file location

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -260,8 +260,8 @@ async def upload(auth_claims: dict[str, Any]):
     file_io = io.BufferedReader(file_io)
     await file_client.upload_data(file_io, overwrite=True, metadata={"UploadedBy": user_oid})
     file_io.seek(0)
-    ingester = current_app.config[CONFIG_INGESTER]
-    await ingester.add_file(File(content=file_io, acls={"oids": [user_oid]}))
+    ingester: UploadUserFileStrategy = current_app.config[CONFIG_INGESTER]
+    await ingester.add_file(File(content=file_io, acls={"oids": [user_oid]}, url=file_client.url))
     return jsonify({"message": "File uploaded successfully"}), 200
 
 

--- a/app/backend/prepdocslib/blobmanager.py
+++ b/app/backend/prepdocslib/blobmanager.py
@@ -53,10 +53,12 @@ class BlobManager:
                 await container_client.create_container()
 
             # Re-open and upload the original file
-            with open(file.content.name, "rb") as reopened_file:
-                blob_name = BlobManager.blob_name_from_file_name(file.content.name)
-                logger.info("Uploading blob for whole file -> %s", blob_name)
-                await container_client.upload_blob(blob_name, reopened_file, overwrite=True)
+            if file.url is None:
+                with open(file.content.name, "rb") as reopened_file:
+                    blob_name = BlobManager.blob_name_from_file_name(file.content.name)
+                    logger.info("Uploading blob for whole file -> %s", blob_name)
+                    blob_client = await container_client.upload_blob(blob_name, reopened_file, overwrite=True)
+                    file.url = blob_client.url
 
             if self.store_page_images:
                 if os.path.splitext(file.content.name)[1].lower() == ".pdf":

--- a/app/backend/prepdocslib/filestrategy.py
+++ b/app/backend/prepdocslib/filestrategy.py
@@ -87,7 +87,7 @@ class FileStrategy(Strategy):
                         blob_image_embeddings: Optional[List[List[float]]] = None
                         if self.image_embeddings and blob_sas_uris:
                             blob_image_embeddings = await self.image_embeddings.create_embeddings(blob_sas_uris)
-                        await search_manager.update_content(sections, blob_image_embeddings)
+                        await search_manager.update_content(sections, blob_image_embeddings, url=file.url)
                 finally:
                     if file:
                         file.close()
@@ -124,7 +124,7 @@ class UploadUserFileStrategy:
             logging.warning("Image embeddings are not currently supported for the user upload feature")
         sections = await parse_file(file, self.file_processors)
         if sections:
-            await self.search_manager.update_content(sections)
+            await self.search_manager.update_content(sections, url=file.url)
 
     async def remove_file(self, filename: str, oid: str):
         if filename is None or filename == "":

--- a/app/backend/prepdocslib/listfilestrategy.py
+++ b/app/backend/prepdocslib/listfilestrategy.py
@@ -22,9 +22,10 @@ class File:
     This file might contain access control information about which users or groups can access it
     """
 
-    def __init__(self, content: IO, acls: Optional[dict[str, list]] = None):
+    def __init__(self, content: IO, acls: Optional[dict[str, list]] = None, url: Optional[str] = None):
         self.content = content
         self.acls = acls or {}
+        self.url = url
 
     def filename(self):
         return os.path.basename(self.content.name)
@@ -167,7 +168,7 @@ class ADLSGen2ListFileStrategy(ListFileStrategy):
                             acls["oids"].append(acl_parts[1])
                         if acl_parts[0] == "group" and "r" in acl_parts[2]:
                             acls["groups"].append(acl_parts[1])
-                    yield File(content=open(temp_file_path, "rb"), acls=acls)
+                    yield File(content=open(temp_file_path, "rb"), acls=acls, url=file_client.url)
                 except Exception as data_lake_exception:
                     logger.error(f"\tGot an error while reading {path} -> {data_lake_exception} --> skipping file")
                     try:

--- a/app/backend/prepdocslib/searchmanager.py
+++ b/app/backend/prepdocslib/searchmanager.py
@@ -115,7 +115,7 @@ class SearchManager:
                     name="storageUrl",
                     type="Edm.String",
                     filterable=True,
-                    facetable=True,
+                    facetable=False,
                 ),
             ]
             if self.use_acls:

--- a/app/backend/prepdocslib/searchmanager.py
+++ b/app/backend/prepdocslib/searchmanager.py
@@ -111,6 +111,12 @@ class SearchManager:
                     filterable=True,
                     facetable=True,
                 ),
+                SimpleField(
+                    name="storageUrl",
+                    type="Edm.String",
+                    filterable=True,
+                    facetable=True,
+                ),
             ]
             if self.use_acls:
                 fields.append(
@@ -182,7 +188,9 @@ class SearchManager:
             else:
                 logger.info("Search index %s already exists", self.search_info.index_name)
 
-    async def update_content(self, sections: List[Section], image_embeddings: Optional[List[List[float]]] = None):
+    async def update_content(
+        self, sections: List[Section], image_embeddings: Optional[List[List[float]]] = None, url: Optional[str] = None
+    ):
         MAX_BATCH_SIZE = 1000
         section_batches = [sections[i : i + MAX_BATCH_SIZE] for i in range(0, len(sections), MAX_BATCH_SIZE)]
 
@@ -209,6 +217,9 @@ class SearchManager:
                     }
                     for section_index, section in enumerate(batch)
                 ]
+                if url:
+                    for document in documents:
+                        document["storageUrl"] = url
                 if self.embeddings:
                     embeddings = await self.embeddings.create_embeddings(
                         texts=[section.split_page.text for section in batch]

--- a/app/frontend/src/components/UploadFile/UploadFile.tsx
+++ b/app/frontend/src/components/UploadFile/UploadFile.tsx
@@ -120,7 +120,7 @@ export const UploadFile: React.FC<Props> = ({ className, disabled }: Props) => {
                             <div>
                                 <Label>Upload file:</Label>
                                 <input
-                                    accept=".txt, .md, .json, .jpg, .jpeg, .bmp, .heic, .tiff, .pdf, .docx, .xlsx, .pptx, .html"
+                                    accept=".txt, .md, .json, .png, .jpg, .jpeg, .bmp, .heic, .tiff, .pdf, .docx, .xlsx, .pptx, .html"
                                     className={styles.chooseFiles}
                                     type="file"
                                     onChange={handleUploadFile}

--- a/docs/deploy_features.md
+++ b/docs/deploy_features.md
@@ -136,6 +136,21 @@ Then you'll need to run `azd up` to provision an Azure Data Lake Storage Gen2 ac
 When the user uploads a document, it will be stored in a directory in that account with the same name as the user's Entra object id,
 and will have ACLs associated with that directory. When the ingester runs, it will also set the `oids` of the indexed chunks to the user's Entra object id.
 
+If you are enabling this feature on an existing index, you should also update your index to have the new `storageUrl` field:
+
+```shell
+./scripts/manageacl.ps1  -v --acl-action enable_acls
+```
+
+And then update existing search documents with the storage URL of the main Blob container:
+
+```shell
+./scripts/manageacl.ps1  -v --acl-action update_storage_urls --url https://st12345.blob.core.windows.net/content/
+```
+
+Going forward, all uploaded documents will have their `storageUrl` set in the search index.
+This is necessary to disambiguate user-uploaded documents from admin-uploaded documents.
+
 
 ## Enabling CORS for an alternate frontend
 

--- a/docs/deploy_features.md
+++ b/docs/deploy_features.md
@@ -145,7 +145,7 @@ If you are enabling this feature on an existing index, you should also update yo
 And then update existing search documents with the storage URL of the main Blob container:
 
 ```shell
-./scripts/manageacl.ps1  -v --acl-action update_storage_urls --url https://st12345.blob.core.windows.net/content/
+./scripts/manageacl.ps1  -v --acl-action update_storage_urls --url <https://YOUR-MAIN-STORAGE-ACCOUNT.blob.core.windows.net/content/>
 ```
 
 Going forward, all uploaded documents will have their `storageUrl` set in the search index.

--- a/docs/login_and_acl.md
+++ b/docs/login_and_acl.md
@@ -150,17 +150,46 @@ Manually enable document level access control on a search index and manually set
 
 Run `azd up` or use `azd env set` to manually set `AZURE_SEARCH_SERVICE` and `AZURE_SEARCH_INDEX` environment variables prior to running the script.
 
-The script supports the following commands. Note that the syntax is the same regardless of whether [manageacl.ps1](../scripts/manageacl.ps1) or [manageacl.sh](../scripts/manageacl.sh) is used.
-* `./scripts/manageacl.ps1 --acl-action enable_acls`: Creates the required `oids` (User ID) and `groups` (Group IDs) [security filter](https://learn.microsoft.com/azure/search/search-security-trimming-for-azure-search) fields for document level access control on your index. Does nothing if these fields already exist.
-  * Example usage: `./scripts/manageacl.ps1 --acl-action enable_acls`
-* `./scripts/manageacl.ps1 --document [name-of-pdf.pdf] --acl-type [oids or groups]--acl-action view`: Prints access control values associated with either User IDs or Group IDs for a specific document.
-  * Example to view all Group IDs from the Benefit_Options PDF: `./scripts/manageacl.ps1 --document Benefit_Options.pdf --acl-type oids --acl-action view`.
-* `./scripts/manageacl.ps1 --document [name-of-pdf.pdf] --acl-type [oids or groups]--acl-action add --acl [ID of group or user]`: Adds an access control value associated with either User IDs or Group IDs for a specific document.
-  * Example to add a Group ID to the Benefit_Options PDF: `./scripts/manageacl.ps1 --document Benefit_Options.pdf --acl-type groups --acl-action add --acl xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
-* `./scripts/manageacl.ps1 --document [name-of-pdf.pdf] --acl-type [oids or groups]--acl-action remove_all`: Removes all access control values associated with either User IDs or Group IDs for a specific document.
-  * Example to remove all Group IDs from the Benefit_Options PDF: `./scripts/manageacl.ps1 --document Benefit_Options.pdf --acl-type groups --acl-action remove_all`.
-* `./scripts/manageacl.ps1 --document [name-of-pdf.pdf] --acl-type [oids or groups]--acl-action remove --acl [ID of group or user]`: Removes an access control value associated with either User IDs or Group IDs for a specific document.
-  * Example to remove a specific User ID from the Benefit_Options PDF: `./scripts/manageacl.ps1 --document Benefit_Options.pdf --acl-type oids --acl-action remove --acl xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
+The script supports the following commands. Note that the syntax is the same regardless of whether [manageacl.ps1](../scripts/manageacl.ps1) or [manageacl.sh](../scripts/manageacl.sh) is used. All commands support `-v` for verbose logging.
+* `./scripts/manageacl.ps1 --acl-action enable_acls`: Creates the required `oids` (User ID) and `groups` (Group IDs) [security filter](https://learn.microsoft.com/azure/search/search-security-trimming-for-azure-search) fields for document level access control on your index, as well as the `storageUrl` field for storing the Blob storage URL. Does nothing if these fields already exist.
+
+  Example usage:
+
+  ```shell
+  ./scripts/manageacl.ps1  -v --acl-action enable_acls
+  ```
+
+* `./scripts/manageacl.ps1 --acl-type [oids or groups]--acl-action view --url [https://url.pdf]`: Prints access control values associated with either User IDs or Group IDs for the document at the specified URL.
+
+  Example to view all Group IDs:
+
+  ```shell
+  ./scripts/manageacl.ps1 -v --acl-type groups --acl-action view --url https://st12345.blob.core.windows.net/content/Benefit_Options.pdf
+  ```
+
+* `./scripts/manageacl.ps1 --url [https://url.pdf] --acl-type [oids or groups]--acl-action add --acl [ID of group or user]`: Adds an access control value associated with either User IDs or Group IDs for the document at the specified URL.
+
+  Example to add a Group ID:
+
+  ```shell
+  ./scripts/manageacl.ps1 -v --acl-type groups --acl-action add --acl xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --url https://st12345.blob.core.windows.net/content/Benefit_Options.pdf
+  ```
+
+* `./scripts/manageacl.ps1 --url [https://url.pdf] --acl-type [oids or groups]--acl-action remove_all`: Removes all access control values associated with either User IDs or Group IDs for a specific document.
+
+  Example to remove all Group IDs:
+
+  ```shell
+  ./scripts/manageacl.ps1 -v --acl-type groups --acl-action remove_all --url https://st12345.blob.core.windows.net/content/Benefit_Options.pdf
+  ```
+
+* `./scripts/manageacl.ps1 --url [https://url.pdf] --acl-type [oids or groups]--acl-action remove --acl [ID of group or user]`: Removes an access control value associated with either User IDs or Group IDs for a specific document.
+
+  Example to remove a specific User ID:
+
+  ```shell
+  ./scripts/manageacl.ps1 -v --acl-type oids --acl-action remove --acl xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --url https://st12345.blob.core.windows.net/content/Benefit_Options.pdf
+  ```
 
 ### Azure Data Lake Storage Gen2 Setup
 

--- a/scripts/manageacl.py
+++ b/scripts/manageacl.py
@@ -170,7 +170,7 @@ class ManageAcl:
                         name="storageUrl",
                         type="Edm.String",
                         filterable=True,
-                        facetable=True,
+                        facetable=False,
                     ),
                 )
             await search_index_client.create_or_update_index(index_definition)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -554,6 +554,9 @@ def mock_data_lake_service_client(monkeypatch):
         self.path = kwargs.get("file_path")
         self.acl = ""
 
+    def mock_url(self, *args, **kwargs):
+        return f"https://test.blob.core.windows.net/{self.path}"
+
     def mock_download_file(self, *args, **kwargs):
         return azure.storage.filedatalake.StorageStreamDownloader(None)
 
@@ -581,6 +584,7 @@ def mock_data_lake_service_client(monkeypatch):
     )
 
     monkeypatch.setattr(azure.storage.filedatalake.aio.DataLakeFileClient, "__init__", mock_init_file)
+    monkeypatch.setattr(azure.storage.filedatalake.aio.DataLakeFileClient, "url", property(mock_url))
     monkeypatch.setattr(azure.storage.filedatalake.aio.DataLakeFileClient, "__aenter__", mock_aenter)
     monkeypatch.setattr(azure.storage.filedatalake.aio.DataLakeFileClient, "__aexit__", mock_aexit)
     monkeypatch.setattr(azure.storage.filedatalake.aio.DataLakeFileClient, "download_file", mock_download_file_aio)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import json
 import os
+from typing import IO
 from unittest import mock
 
 import aiohttp
@@ -560,7 +561,7 @@ def mock_data_lake_service_client(monkeypatch):
     def mock_download_file(self, *args, **kwargs):
         return azure.storage.filedatalake.StorageStreamDownloader(None)
 
-    def mock_download_file_aio(self, *args, **kwargs):
+    async def mock_download_file_aio(self, *args, **kwargs):
         return azure.storage.filedatalake.aio.StorageStreamDownloader(None)
 
     async def mock_get_access_control(self, *args, **kwargs):
@@ -629,8 +630,9 @@ def mock_data_lake_service_client(monkeypatch):
     )
     monkeypatch.setattr(azure.storage.filedatalake.aio.DataLakeDirectoryClient, "close", mock_close_aio)
 
-    def mock_readinto(self, *args, **kwargs):
-        pass
+    def mock_readinto(self, stream: IO[bytes]):
+        stream.write(b"texttext")
+        return 8
 
     monkeypatch.setattr(azure.storage.filedatalake.StorageStreamDownloader, "__init__", mock_init)
     monkeypatch.setattr(azure.storage.filedatalake.StorageStreamDownloader, "readinto", mock_readinto)

--- a/tests/test_blob_manager.py
+++ b/tests/test_blob_manager.py
@@ -2,6 +2,7 @@ import os
 import sys
 from tempfile import NamedTemporaryFile
 
+import azure.storage.blob.aio
 import pytest
 
 from prepdocslib.blobmanager import BlobManager
@@ -37,11 +38,14 @@ async def test_upload_and_remove(monkeypatch, mock_env, blob_manager):
 
         async def mock_upload_blob(self, name, *args, **kwargs):
             assert name == filename
-            return True
+            return azure.storage.blob.aio.BlobClient.from_blob_url(
+                "https://test.blob.core.windows.net/test/test.pdf", credential=MockAzureCredential()
+            )
 
         monkeypatch.setattr("azure.storage.blob.aio.ContainerClient.upload_blob", mock_upload_blob)
 
         await blob_manager.upload_blob(f)
+        assert f.url == "https://test.blob.core.windows.net/test/test.pdf"
 
         # Set up mocks used by remove_blob
         def mock_list_blob_names(*args, **kwargs):
@@ -87,11 +91,14 @@ async def test_upload_and_remove_all(monkeypatch, mock_env, blob_manager):
 
         async def mock_upload_blob(self, name, *args, **kwargs):
             assert name == filename
-            return True
+            return azure.storage.blob.aio.BlobClient.from_blob_url(
+                "https://test.blob.core.windows.net/test/test.pdf", credential=MockAzureCredential()
+            )
 
         monkeypatch.setattr("azure.storage.blob.aio.ContainerClient.upload_blob", mock_upload_blob)
 
         await blob_manager.upload_blob(f)
+        assert f.url == "https://test.blob.core.windows.net/test/test.pdf"
 
         # Set up mocks used by remove_blob
         def mock_list_blob_names(*args, **kwargs):
@@ -142,11 +149,14 @@ async def test_create_container_upon_upload(monkeypatch, mock_env, blob_manager)
 
         async def mock_upload_blob(self, name, *args, **kwargs):
             assert name == filename
-            return True
+            return azure.storage.blob.aio.BlobClient.from_blob_url(
+                "https://test.blob.core.windows.net/test/test.pdf", credential=MockAzureCredential()
+            )
 
         monkeypatch.setattr("azure.storage.blob.aio.ContainerClient.upload_blob", mock_upload_blob)
 
         await blob_manager.upload_blob(f)
+        assert f.url == "https://test.blob.core.windows.net/test/test.pdf"
 
 
 @pytest.mark.asyncio
@@ -174,12 +184,15 @@ async def test_upload_blob_no_image(monkeypatch, mock_env, caplog):
 
         async def mock_upload_blob(self, name, *args, **kwargs):
             assert name == filename
-            return True
+            return azure.storage.blob.aio.BlobClient.from_blob_url(
+                "https://test.blob.core.windows.net/test/test.xlsx", credential=MockAzureCredential()
+            )
 
         monkeypatch.setattr("azure.storage.blob.aio.ContainerClient.upload_blob", mock_upload_blob)
 
         with caplog.at_level("INFO"):
             await blob_manager.upload_blob(f)
+            assert f.url == "https://test.blob.core.windows.net/test/test.xlsx"
             assert "skipping image upload" in caplog.text
 
 

--- a/tests/test_manageacl.py
+++ b/tests/test_manageacl.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from azure.search.documents.aio import SearchClient
 from azure.search.documents.indexes.aio import SearchIndexClient
@@ -30,7 +32,7 @@ class AsyncSearchResultsIterator:
 @pytest.mark.asyncio
 async def test_view_acl(monkeypatch, capsys):
     async def mock_search(self, *args, **kwargs):
-        assert kwargs.get("filter") == "sourcefile eq 'a.txt'"
+        assert kwargs.get("filter") == "storageUrl eq 'https://test.blob.core.windows.net/content/a.txt'"
         assert kwargs.get("select") == ["id", "oids"]
         return AsyncSearchResultsIterator([{"oids": ["OID_ACL"]}])
 
@@ -39,7 +41,7 @@ async def test_view_acl(monkeypatch, capsys):
     command = ManageAcl(
         service_name="SERVICE",
         index_name="INDEX",
-        document="a.txt",
+        url="https://test.blob.core.windows.net/content/a.txt",
         acl_action="view",
         acl_type="oids",
         acl="",
@@ -53,7 +55,7 @@ async def test_view_acl(monkeypatch, capsys):
 @pytest.mark.asyncio
 async def test_remove_acl(monkeypatch, capsys):
     async def mock_search(self, *args, **kwargs):
-        assert kwargs.get("filter") == "sourcefile eq 'a.txt'"
+        assert kwargs.get("filter") == "storageUrl eq 'https://test.blob.core.windows.net/content/a.txt'"
         assert kwargs.get("select") == ["id", "oids"]
         return AsyncSearchResultsIterator(
             [
@@ -74,7 +76,7 @@ async def test_remove_acl(monkeypatch, capsys):
     command = ManageAcl(
         service_name="SERVICE",
         index_name="INDEX",
-        document="a.txt",
+        url="https://test.blob.core.windows.net/content/a.txt",
         acl_action="remove",
         acl_type="oids",
         acl="OID_ACL_TO_REMOVE",
@@ -87,7 +89,7 @@ async def test_remove_acl(monkeypatch, capsys):
 @pytest.mark.asyncio
 async def test_remove_all_acl(monkeypatch, capsys):
     async def mock_search(self, *args, **kwargs):
-        assert kwargs.get("filter") == "sourcefile eq 'a.txt'"
+        assert kwargs.get("filter") == "storageUrl eq 'https://test.blob.core.windows.net/content/a.txt'"
         assert kwargs.get("select") == ["id", "oids"]
         return AsyncSearchResultsIterator(
             [
@@ -108,7 +110,7 @@ async def test_remove_all_acl(monkeypatch, capsys):
     command = ManageAcl(
         service_name="SERVICE",
         index_name="INDEX",
-        document="a.txt",
+        url="https://test.blob.core.windows.net/content/a.txt",
         acl_action="remove_all",
         acl_type="oids",
         acl="",
@@ -119,9 +121,9 @@ async def test_remove_all_acl(monkeypatch, capsys):
 
 
 @pytest.mark.asyncio
-async def test_add_acl(monkeypatch, capsys):
+async def test_add_acl(monkeypatch, caplog):
     async def mock_search(self, *args, **kwargs):
-        assert kwargs.get("filter") == "sourcefile eq 'a.txt'"
+        assert kwargs.get("filter") == "storageUrl eq 'https://test.blob.core.windows.net/content/a.txt'"
         assert kwargs.get("select") == ["id", "oids"]
         return AsyncSearchResultsIterator([{"id": 1, "oids": ["OID_EXISTS"]}, {"id": 2, "oids": ["OID_EXISTS"]}])
 
@@ -137,75 +139,36 @@ async def test_add_acl(monkeypatch, capsys):
     command = ManageAcl(
         service_name="SERVICE",
         index_name="INDEX",
-        document="a.txt",
+        url="https://test.blob.core.windows.net/content/a.txt",
         acl_action="add",
         acl_type="oids",
         acl="OID_EXISTS",
         credentials=MockAzureCredential(),
     )
-    await command.run()
-    assert merged_documents == [{"id": 2, "oids": ["OID_EXISTS"]}, {"id": 1, "oids": ["OID_EXISTS"]}]
+    with caplog.at_level(logging.INFO):
+        await command.run()
+        assert merged_documents == []
+        assert "Search document 1 already has oids acl OID_EXISTS" in caplog.text
+        assert "Search document 2 already has oids acl OID_EXISTS" in caplog.text
+        assert "Not updating any search documents" in caplog.text
 
     merged_documents.clear()
     command = ManageAcl(
         service_name="SERVICE",
         index_name="INDEX",
-        document="a.txt",
+        url="https://test.blob.core.windows.net/content/a.txt",
         acl_action="add",
         acl_type="oids",
         acl="OID_ADD",
         credentials=MockAzureCredential(),
     )
-    await command.run()
-    assert merged_documents == [
-        {"id": 2, "oids": ["OID_EXISTS", "OID_ADD"]},
-        {"id": 1, "oids": ["OID_EXISTS", "OID_ADD"]},
-    ]
-
-
-@pytest.mark.asyncio
-async def test_add_acl_already_exists(monkeypatch, capsys):
-    async def mock_search(self, *args, **kwargs):
-        assert kwargs.get("filter") == "sourcefile eq 'a.txt'"
-        assert kwargs.get("select") == ["id", "oids"]
-        return AsyncSearchResultsIterator([{"id": 1, "oids": ["OID_EXISTS"]}, {"id": 2, "oids": ["OID_EXISTS"]}])
-
-    merged_documents = []
-
-    async def mock_merge_documents(self, *args, **kwargs):
-        for document in kwargs.get("documents"):
-            merged_documents.append(document)
-
-    monkeypatch.setattr(SearchClient, "search", mock_search)
-    monkeypatch.setattr(SearchClient, "merge_documents", mock_merge_documents)
-
-    command = ManageAcl(
-        service_name="SERVICE",
-        index_name="INDEX",
-        document="a.txt",
-        acl_action="add",
-        acl_type="oids",
-        acl="OID_EXISTS",
-        credentials=MockAzureCredential(),
-    )
-    await command.run()
-    assert merged_documents == [{"id": 2, "oids": ["OID_EXISTS"]}, {"id": 1, "oids": ["OID_EXISTS"]}]
-
-    merged_documents.clear()
-    command = ManageAcl(
-        service_name="SERVICE",
-        index_name="INDEX",
-        document="a.txt",
-        acl_action="add",
-        acl_type="oids",
-        acl="OID_ADD",
-        credentials=MockAzureCredential(),
-    )
-    await command.run()
-    assert merged_documents == [
-        {"id": 2, "oids": ["OID_EXISTS", "OID_ADD"]},
-        {"id": 1, "oids": ["OID_EXISTS", "OID_ADD"]},
-    ]
+    with caplog.at_level(logging.INFO):
+        await command.run()
+        assert merged_documents == [
+            {"id": 2, "oids": ["OID_EXISTS", "OID_ADD"]},
+            {"id": 1, "oids": ["OID_EXISTS", "OID_ADD"]},
+        ]
+        assert "Adding acl OID_ADD to 2 search documents" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -224,7 +187,7 @@ async def test_enable_acls_with_missing_fields(monkeypatch, capsys):
     command = ManageAcl(
         service_name="SERVICE",
         index_name="INDEX",
-        document="",
+        url="",
         acl_action="enable_acls",
         acl_type="",
         acl="",
@@ -266,7 +229,7 @@ async def test_enable_acls_without_missing_fields(monkeypatch, capsys):
     command = ManageAcl(
         service_name="SERVICE",
         index_name="INDEX",
-        document="",
+        url="",
         acl_action="enable_acls",
         acl_type="",
         acl="",
@@ -279,9 +242,10 @@ async def test_enable_acls_without_missing_fields(monkeypatch, capsys):
 
 
 def validate_index(index):
-    assert len(index.fields) == 2
+    assert len(index.fields) == 3
     oids_field = None
     groups_field = None
+    storageurl_field = None
     for field in index.fields:
         if field.name == "oids":
             assert not oids_field
@@ -289,8 +253,12 @@ def validate_index(index):
         elif field.name == "groups":
             assert not groups_field
             groups_field = field
-    assert oids_field and groups_field
+        elif field.name == "storageUrl":
+            storageurl_field = field
+
+    assert oids_field and groups_field and storageurl_field
     assert oids_field.type == SearchFieldDataType.Collection(
         SearchFieldDataType.String
     ) and groups_field.type == SearchFieldDataType.Collection(SearchFieldDataType.String)
-    assert oids_field.filterable and groups_field.filterable
+    assert storageurl_field.type == SearchFieldDataType.String
+    assert oids_field.filterable and groups_field.filterable and storageurl_field.filterable

--- a/tests/test_prepdocslib_filestrategy.py
+++ b/tests/test_prepdocslib_filestrategy.py
@@ -1,0 +1,103 @@
+import os
+
+import pytest
+from azure.search.documents.aio import SearchClient
+
+from prepdocslib.blobmanager import BlobManager
+from prepdocslib.fileprocessor import FileProcessor
+from prepdocslib.filestrategy import FileStrategy
+from prepdocslib.listfilestrategy import (
+    ADLSGen2ListFileStrategy,
+)
+from prepdocslib.strategy import SearchInfo
+from prepdocslib.textparser import TextParser
+from prepdocslib.textsplitter import SimpleTextSplitter
+
+from .mocks import MockAzureCredential
+
+
+@pytest.mark.asyncio
+async def test_file_strategy_adls2(monkeypatch, mock_env, mock_data_lake_service_client):
+    adlsgen2_list_strategy = ADLSGen2ListFileStrategy(
+        data_lake_storage_account="a", data_lake_filesystem="a", data_lake_path="a", credential=MockAzureCredential()
+    )
+    blob_manager = BlobManager(
+        endpoint=f"https://{os.environ['AZURE_STORAGE_ACCOUNT']}.blob.core.windows.net",
+        credential=MockAzureCredential(),
+        container=os.environ["AZURE_STORAGE_CONTAINER"],
+        account=os.environ["AZURE_STORAGE_ACCOUNT"],
+        resourceGroup=os.environ["AZURE_STORAGE_RESOURCE_GROUP"],
+        subscriptionId=os.environ["AZURE_SUBSCRIPTION_ID"],
+        store_page_images=False,
+    )
+
+    # Set up mocks used by upload_blob
+    async def mock_exists(*args, **kwargs):
+        return True
+
+    monkeypatch.setattr("azure.storage.blob.aio.ContainerClient.exists", mock_exists)
+
+    uploaded_to_blob = []
+
+    async def mock_upload_blob(self, name, *args, **kwargs):
+        uploaded_to_blob.append(name)
+
+    monkeypatch.setattr("azure.storage.blob.aio.ContainerClient.upload_blob", mock_upload_blob)
+
+    search_info = SearchInfo(
+        endpoint="https://testsearchclient.blob.core.windows.net",
+        credential=MockAzureCredential(),
+        index_name="test",
+    )
+
+    uploaded_to_search = []
+
+    async def mock_upload_documents(self, documents):
+        uploaded_to_search.extend(documents)
+
+    monkeypatch.setattr(SearchClient, "upload_documents", mock_upload_documents)
+
+    file_strategy = FileStrategy(
+        list_file_strategy=adlsgen2_list_strategy,
+        blob_manager=blob_manager,
+        search_info=search_info,
+        file_processors={".txt": FileProcessor(TextParser(), SimpleTextSplitter())},
+        use_acls=True,
+    )
+
+    await file_strategy.run()
+
+    assert len(uploaded_to_blob) == 0
+    assert len(uploaded_to_search) == 3
+    assert uploaded_to_search == [
+        {
+            "id": "file-a_txt-612E7478747B276F696473273A205B27412D555345522D4944275D2C202767726F757073273A205B27412D47524F55502D4944275D7D-page-0",
+            "content": "texttext",
+            "category": None,
+            "groups": ["A-GROUP-ID"],
+            "oids": ["A-USER-ID"],
+            "sourcepage": "a.txt",
+            "sourcefile": "a.txt",
+            "storageUrl": "https://test.blob.core.windows.net/a.txt",
+        },
+        {
+            "id": "file-b_txt-622E7478747B276F696473273A205B27422D555345522D4944275D2C202767726F757073273A205B27422D47524F55502D4944275D7D-page-0",
+            "content": "texttext",
+            "category": None,
+            "groups": ["B-GROUP-ID"],
+            "oids": ["B-USER-ID"],
+            "sourcepage": "b.txt",
+            "sourcefile": "b.txt",
+            "storageUrl": "https://test.blob.core.windows.net/b.txt",
+        },
+        {
+            "id": "file-c_txt-632E7478747B276F696473273A205B27432D555345522D4944275D2C202767726F757073273A205B27432D47524F55502D4944275D7D-page-0",
+            "content": "texttext",
+            "category": None,
+            "groups": ["C-GROUP-ID"],
+            "oids": ["C-USER-ID"],
+            "sourcepage": "c.txt",
+            "sourcefile": "c.txt",
+            "storageUrl": "https://test.blob.core.windows.net/c.txt",
+        },
+    ]

--- a/tests/test_searchmanager.py
+++ b/tests/test_searchmanager.py
@@ -86,7 +86,7 @@ async def test_create_index_doesnt_exist_yet(monkeypatch, search_info):
     await manager.create_index()
     assert len(indexes) == 1, "It should have created one index"
     assert indexes[0].name == "test"
-    assert len(indexes[0].fields) == 6
+    assert len(indexes[0].fields) == 7
 
 
 @pytest.mark.asyncio
@@ -107,7 +107,7 @@ async def test_create_index_using_int_vectorization(monkeypatch, search_info):
     await manager.create_index()
     assert len(indexes) == 1, "It should have created one index"
     assert indexes[0].name == "test"
-    assert len(indexes[0].fields) == 7
+    assert len(indexes[0].fields) == 8
 
 
 @pytest.mark.asyncio
@@ -149,7 +149,7 @@ async def test_create_index_acls(monkeypatch, search_info):
     await manager.create_index()
     assert len(indexes) == 1, "It should have created one index"
     assert indexes[0].name == "test"
-    assert len(indexes[0].fields) == 8
+    assert len(indexes[0].fields) == 9
 
 
 @pytest.mark.asyncio

--- a/tests/test_searchmanager.py
+++ b/tests/test_searchmanager.py
@@ -31,43 +31,6 @@ def search_info():
     )
 
 
-@pytest.fixture
-def embeddings_service(monkeypatch):
-    async def mock_create_client(*args, **kwargs):
-        # From https://platform.openai.com/docs/api-reference/embeddings/create
-        return MockClient(
-            embeddings_client=MockEmbeddingsClient(
-                create_embedding_response=openai.types.CreateEmbeddingResponse(
-                    object="list",
-                    data=[
-                        openai.types.Embedding(
-                            embedding=[
-                                0.0023064255,
-                                -0.009327292,
-                                -0.0028842222,
-                            ],
-                            index=0,
-                            object="embedding",
-                        )
-                    ],
-                    model="text-embedding-ada-002",
-                    usage=Usage(prompt_tokens=8, total_tokens=8),
-                )
-            )
-        )
-
-    embeddings = AzureOpenAIEmbeddingService(
-        open_ai_service="x",
-        open_ai_deployment="x",
-        open_ai_model_name=MOCK_EMBEDDING_MODEL_NAME,
-        open_ai_dimensions=MOCK_EMBEDDING_DIMENSIONS,
-        credential=AzureKeyCredential("test"),
-        disable_batch=True,
-    )
-    monkeypatch.setattr(embeddings, "create_client", mock_create_client)
-    return embeddings
-
-
 @pytest.mark.asyncio
 async def test_create_index_doesnt_exist_yet(monkeypatch, search_info):
     indexes = []

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -45,11 +45,9 @@ async def test_upload_file(auth_client, monkeypatch, mock_data_lake_service_clie
     monkeypatch.setattr(DataLakeDirectoryClient, "set_access_control", mock_directory_set_access_control)
 
     def mock_directory_get_file_client(self, *args, **kwargs):
-        path = kwargs.get("file")
-        if path in self.files:
-            return self.files[path]
-        self.files[path] = DataLakeFileClient(path)
-        return self.files[path]
+        return azure.storage.filedatalake.aio.DataLakeFileClient(
+            account_url="https://test.blob.core.windows.net/", file_system_name="user-content", file_path=args[0]
+        )
 
     monkeypatch.setattr(DataLakeDirectoryClient, "get_file_client", mock_directory_get_file_client)
 
@@ -149,6 +147,13 @@ async def test_delete_uploaded(auth_client, monkeypatch, mock_data_lake_service_
         return None
 
     monkeypatch.setattr(DataLakeFileClient, "delete_file", mock_delete_file)
+
+    def mock_directory_get_file_client(self, *args, **kwargs):
+        return azure.storage.filedatalake.aio.DataLakeFileClient(
+            account_url="https://test.blob.core.windows.net/", file_system_name="user-content", file_path=args[0]
+        )
+
+    monkeypatch.setattr(DataLakeDirectoryClient, "get_file_client", mock_directory_get_file_client)
 
     class AsyncSearchResultsIterator:
         def __init__(self):


### PR DESCRIPTION
## Purpose

Fixes #1531 
Possibly fixes #1424

With the recent addition of the user upload feature, it is now possible for a file with the same filename to exist in two places (either the user's storage container or the global content container). I accounted for that in terms of searching and user deletion, but realized that manageacls.py didn't have a way to unambiguously identify what document's ACLs to update. 

So this PR adds a new field "storageUrl" that stores the full Blob storage URL (*not* with any SAS tokens however), and changes manageacls.py to expect a full URL to be passed in. It's slightly more work since you need to go into Blob storage and copy the URL from the portal, but much more clear what document you're trying to ACL.

I also improved logging in manageacls.py so that we can recommend the verbose flag always and provide more details about whether we've successfully found the document, found acls to remove, etc.

I also added a quick fix for #1424 to avoid uploading to BlobStorage in the case that a file has an existing blob storage URL (which is true for ADLS2 sources). I don't have an azd environment to test that out yet however, and we still have to improve GPT-4-vision code path so it uploads page images to the right place.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`)
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
