### PR TITLE
Fix gunicorn config to use single worker for free sku

### DIFF
--- a/app/backend/gunicorn.conf.py
+++ b/app/backend/gunicorn.conf.py
@@ -1,4 +1,5 @@
 import multiprocessing
+import os
 
 max_requests = 1000
 max_requests_jitter = 50
@@ -9,5 +10,9 @@ timeout = 230
 # https://learn.microsoft.com/en-us/troubleshoot/azure/app-service/web-apps-performance-faqs#why-does-my-request-time-out-after-230-seconds
 
 num_cpus = multiprocessing.cpu_count()
-workers = (num_cpus * 2) + 1
+if os.getenv("WEBSITE_SKU") == "LinuxFree":
+    # Free tier reports 2 CPUs but can't handle multiple workers
+    workers = 1
+else:
+    workers = (num_cpus * 2) + 1
 worker_class = "uvicorn.workers.UvicornWorker"


### PR DESCRIPTION
## Purpose

Fixes #1495

The cpu_count() reports 2 which results in 5 workers, but they get killed due to lack of memory. So instead we only use 1 if we detect we're running on free tier.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [X] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works: N/A, just deployed
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [X] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
