### PR TITLE
Disable OpenAI key access

### DIFF
--- a/infra/core/ai/cognitiveservices.bicep
+++ b/infra/core/ai/cognitiveservices.bicep
@@ -4,6 +4,7 @@ param location string = resourceGroup().location
 param tags object = {}
 @description('The custom subdomain name used to access the API. Defaults to the value of the name parameter.')
 param customSubDomainName string = name
+param disableLocalAuth bool = false
 param deployments array = []
 param kind string = 'OpenAI'
 
@@ -30,6 +31,7 @@ resource account 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
     customSubDomainName: customSubDomainName
     publicNetworkAccess: publicNetworkAccess
     networkAcls: networkAcls
+    disableLocalAuth: disableLocalAuth
   }
   sku: sku
 }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -361,6 +361,7 @@ module openAi 'core/ai/cognitiveservices.bicep' = if (isAzureOpenAiHost) {
       name: openAiSkuName
     }
     deployments: openAiDeployments
+    disableLocalAuth: true
   }
 }
 


### PR DESCRIPTION
## Purpose

This pull request introduces changes to the `infra/core/ai/cognitiveservices.bicep` and `infra/main.bicep` files to add a new parameter `disableLocalAuth` to the cognitive services configuration and to set its value in the main configuration to true.

This improves security since it means that only keyless auth can be used with the OpenAI service.


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix - Security alert
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`): n/a
- [ ] I added tests that prove my fix is effective or that my feature works: n/a
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines: n/a
- [ ] I ran `python -m mypy` to check for type errors: n/a
- [X] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.

I deployed, checked deployed, and checked local auth and prepdocs.