### PR TITLE
Add storageurl field

### DIFF
--- a/app/backend/prepdocslib/searchmanager.py
+++ b/app/backend/prepdocslib/searchmanager.py
@@ -187,6 +187,18 @@ class SearchManager:
                 await search_index_client.create_index(index)
             else:
                 logger.info("Search index %s already exists", self.search_info.index_name)
+                index_definition = await search_index_client.get_index(self.search_info.index_name)
+                if not any(field.name == "storageUrl" for field in index_definition.fields):
+                    logger.info("Adding storageUrl field to index %s", self.search_info.index_name)
+                    index_definition.fields.append(
+                        SimpleField(
+                            name="storageUrl",
+                            type="Edm.String",
+                            filterable=True,
+                            facetable=False,
+                        ),
+                    )
+                    await search_index_client.create_or_update_index(index_definition)
 
     async def update_content(
         self, sections: List[Section], image_embeddings: Optional[List[List[float]]] = None, url: Optional[str] = None

--- a/tests/test_searchmanager.py
+++ b/tests/test_searchmanager.py
@@ -6,6 +6,11 @@ import pytest
 from azure.core.credentials import AzureKeyCredential
 from azure.search.documents.aio import SearchClient
 from azure.search.documents.indexes.aio import SearchIndexClient
+from azure.search.documents.indexes.models import (
+    SearchFieldDataType,
+    SearchIndex,
+    SimpleField,
+)
 from openai.types.create_embedding_response import Usage
 
 from prepdocslib.embeddings import AzureOpenAIEmbeddingService
@@ -75,20 +80,72 @@ async def test_create_index_using_int_vectorization(monkeypatch, search_info):
 
 @pytest.mark.asyncio
 async def test_create_index_does_exist(monkeypatch, search_info):
-    indexes = []
+    created_indexes = []
+    updated_indexes = []
 
     async def mock_create_index(self, index):
-        indexes.append(index)
+        created_indexes.append(index)
 
     async def mock_list_index_names(self):
         yield "test"
 
+    async def mock_get_index(self, *args, **kwargs):
+        return SearchIndex(
+            name="test",
+            fields=[
+                SimpleField(
+                    name="storageUrl",
+                    type=SearchFieldDataType.String,
+                    filterable=True,
+                )
+            ],
+        )
+
+    async def mock_create_or_update_index(self, index, *args, **kwargs):
+        updated_indexes.append(index)
+
     monkeypatch.setattr(SearchIndexClient, "create_index", mock_create_index)
     monkeypatch.setattr(SearchIndexClient, "list_index_names", mock_list_index_names)
+    monkeypatch.setattr(SearchIndexClient, "get_index", mock_get_index)
+    monkeypatch.setattr(SearchIndexClient, "create_or_update_index", mock_create_or_update_index)
 
     manager = SearchManager(search_info)
     await manager.create_index()
-    assert len(indexes) == 0, "It should not have created a new index"
+    assert len(created_indexes) == 0, "It should not have created a new index"
+    assert len(updated_indexes) == 0, "It should not have updated the existing index"
+
+
+@pytest.mark.asyncio
+async def test_create_index_add_field(monkeypatch, search_info):
+    created_indexes = []
+    updated_indexes = []
+
+    async def mock_create_index(self, index):
+        created_indexes.append(index)
+
+    async def mock_list_index_names(self):
+        yield "test"
+
+    async def mock_get_index(self, *args, **kwargs):
+        return SearchIndex(
+            name="test",
+            fields=[],
+        )
+
+    async def mock_create_or_update_index(self, index, *args, **kwargs):
+        updated_indexes.append(index)
+
+    monkeypatch.setattr(SearchIndexClient, "create_index", mock_create_index)
+    monkeypatch.setattr(SearchIndexClient, "list_index_names", mock_list_index_names)
+    monkeypatch.setattr(SearchIndexClient, "get_index", mock_get_index)
+    monkeypatch.setattr(SearchIndexClient, "create_or_update_index", mock_create_or_update_index)
+
+    manager = SearchManager(search_info)
+    await manager.create_index()
+    assert len(created_indexes) == 0, "It should not have created a new index"
+    assert len(updated_indexes) == 1, "It should have updated the existing index"
+    assert len(updated_indexes[0].fields) == 1
+    assert updated_indexes[0].fields[0].name == "storageUrl"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Purpose

This pull request includes a change to the `create_index` method in the `app/backend/prepdocslib/searchmanager.py` file. The change checks if the `storageUrl` field exists in the index definition and if it doesn't, the field is added and the index is updated.

The other approach would be to only store storageUrl if ACLs are enabled, but I thought it was a useful field to have regardless.


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [X] The current tests all pass (`python -m pytest`).
- [X] I added tests that prove my fix is effective or that my feature works
- [X] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [X] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
