### PR TITLE
Escape single quote marks for search filters

### DIFF
--- a/app/backend/core/authentication.py
+++ b/app/backend/core/authentication.py
@@ -253,7 +253,10 @@ class AuthenticationHelper:
 
         # Filter down to only chunks that are from the specific source file
         # Sourcepage is used for GPT-4V
-        filter = f"{security_filter} and ((sourcefile eq '{path}') or (sourcepage eq '{path}'))"
+        # Replace ' with '' to escape the single quote for the filter
+        # https://learn.microsoft.com/azure/search/query-odata-filter-orderby-syntax#escaping-special-characters-in-string-constants
+        path_for_filter = path.replace("'", "''")
+        filter = f"{security_filter} and ((sourcefile eq '{path_for_filter}') or (sourcepage eq '{path_for_filter}'))"
 
         # If the filter returns any results, the user is allowed to access the document
         # Otherwise, access is denied

--- a/app/backend/prepdocslib/searchmanager.py
+++ b/app/backend/prepdocslib/searchmanager.py
@@ -250,7 +250,10 @@ class SearchManager:
         )
         async with self.search_info.create_search_client() as search_client:
             while True:
-                filter = None if path is None else f"sourcefile eq '{os.path.basename(path)}'"
+                # Replace ' with '' to escape the single quote for the filter
+                # https://learn.microsoft.com/azure/search/query-odata-filter-orderby-syntax#escaping-special-characters-in-string-constants
+                path_for_filter = os.path.basename(path).replace("'", "''")
+                filter = None if path is None else f"sourcefile eq '{path_for_filter}'"
                 max_results = 1000
                 result = await search_client.search(
                     search_text="", filter=filter, top=max_results, include_total_count=True

--- a/app/backend/prepdocslib/searchmanager.py
+++ b/app/backend/prepdocslib/searchmanager.py
@@ -250,10 +250,12 @@ class SearchManager:
         )
         async with self.search_info.create_search_client() as search_client:
             while True:
-                # Replace ' with '' to escape the single quote for the filter
-                # https://learn.microsoft.com/azure/search/query-odata-filter-orderby-syntax#escaping-special-characters-in-string-constants
-                path_for_filter = os.path.basename(path).replace("'", "''")
-                filter = None if path is None else f"sourcefile eq '{path_for_filter}'"
+                filter = None
+                if path is not None:
+                    # Replace ' with '' to escape the single quote for the filter
+                    # https://learn.microsoft.com/azure/search/query-odata-filter-orderby-syntax#escaping-special-characters-in-string-constants
+                    path_for_filter = os.path.basename(path).replace("'", "''")
+                    filter = f"sourcefile eq '{path_for_filter}'"
                 max_results = 1000
                 result = await search_client.search(
                     search_text="", filter=filter, top=max_results, include_total_count=True

--- a/tests/test_authenticationhelper.py
+++ b/tests/test_authenticationhelper.py
@@ -206,7 +206,7 @@ async def test_check_path_auth_allowed_sourcepage(
 
     assert (
         await auth_helper_require_access_control.check_path_auth(
-            path="Benefit_Options-2.pdf",
+            path="Benefit_Options-2's complement.pdf",
             auth_claims={"oid": "OID_X", "groups": ["GROUP_Y", "GROUP_Z"]},
             search_client=create_search_client(),
         )
@@ -214,7 +214,7 @@ async def test_check_path_auth_allowed_sourcepage(
     )
     assert (
         filter
-        == "(oids/any(g:search.in(g, 'OID_X')) or groups/any(g:search.in(g, 'GROUP_Y, GROUP_Z'))) and ((sourcefile eq 'Benefit_Options-2.pdf') or (sourcepage eq 'Benefit_Options-2.pdf'))"
+        == "(oids/any(g:search.in(g, 'OID_X')) or groups/any(g:search.in(g, 'GROUP_Y, GROUP_Z'))) and ((sourcefile eq 'Benefit_Options-2''s complement.pdf') or (sourcepage eq 'Benefit_Options-2''s complement.pdf'))"
     )
 
 

--- a/tests/test_searchmanager.py
+++ b/tests/test_searchmanager.py
@@ -334,8 +334,8 @@ async def test_remove_content(monkeypatch, search_info):
                 "id": "file-foo_pdf-666F6F2E706466-page-0",
                 "content": "test content",
                 "category": "test",
-                "sourcepage": "foo.pdf#page=1",
-                "sourcefile": "foo.pdf",
+                "sourcepage": "foo's bar.pdf#page=1",
+                "sourcefile": "foo's bar.pdf",
             }
         ]
     )
@@ -359,10 +359,10 @@ async def test_remove_content(monkeypatch, search_info):
 
     manager = SearchManager(search_info)
 
-    await manager.remove_content("foo.pdf")
+    await manager.remove_content("foo's bar.pdf")
 
     assert len(searched_filters) == 2, "It should have searched twice (with no results on second try)"
-    assert searched_filters[0] == "sourcefile eq 'foo.pdf'"
+    assert searched_filters[0] == "sourcefile eq 'foo''s bar.pdf'"
     assert len(deleted_documents) == 1, "It should have deleted one document"
     assert deleted_documents[0]["id"] == "file-foo_pdf-666F6F2E706466-page-0"
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -159,8 +159,8 @@ async def test_delete_uploaded(auth_client, monkeypatch, mock_data_lake_service_
         def __init__(self):
             self.results = [
                 {
-                    "sourcepage": "a.txt",
-                    "sourcefile": "a.txt",
+                    "sourcepage": "a's doc.txt",
+                    "sourcefile": "a's doc.txt",
                     "content": "This is a test document.",
                     "embedding": [],
                     "category": None,
@@ -170,8 +170,8 @@ async def test_delete_uploaded(auth_client, monkeypatch, mock_data_lake_service_
                     "@search.reranker_score": 3.4577205181121826,
                 },
                 {
-                    "sourcepage": "a.txt",
-                    "sourcefile": "a.txt",
+                    "sourcepage": "a's doc.txt",
+                    "sourcefile": "a's doc.txt",
                     "content": "This is a test document.",
                     "embedding": [],
                     "category": None,
@@ -181,8 +181,8 @@ async def test_delete_uploaded(auth_client, monkeypatch, mock_data_lake_service_
                     "@search.reranker_score": 3.4577205181121826,
                 },
                 {
-                    "sourcepage": "a.txt",
-                    "sourcefile": "a.txt",
+                    "sourcepage": "a's doc.txt",
+                    "sourcefile": "a's doc.txt",
                     "content": "This is a test document.",
                     "embedding": [],
                     "category": None,
@@ -224,10 +224,10 @@ async def test_delete_uploaded(auth_client, monkeypatch, mock_data_lake_service_
     monkeypatch.setattr(SearchClient, "delete_documents", mock_delete_documents)
 
     response = await auth_client.post(
-        "/delete_uploaded", headers={"Authorization": "Bearer test"}, json={"filename": "a.txt"}
+        "/delete_uploaded", headers={"Authorization": "Bearer test"}, json={"filename": "a's doc.txt"}
     )
     assert response.status_code == 200
     assert len(searched_filters) == 2, "It should have searched twice (with no results on second try)"
-    assert searched_filters[0] == "sourcefile eq 'a.txt'"
+    assert searched_filters[0] == "sourcefile eq 'a''s doc.txt'"
     assert len(deleted_documents) == 1, "It should have only deleted the document solely owned by OID_X"
     assert deleted_documents[0]["id"] == "file-a_txt-7465737420646F63756D656E742E706466"


### PR DESCRIPTION
## Purpose

Fixes #1591 

This PR escapes apostrophes using the strategy suggested in the Azure AI Search docs, which I've linked in the code. I changed the tests to have apostrophes in their names, but I could also duplicate the existing tests if we want it to be One Test per One Bug.

I manually tested this by uploading a PDF with an apostrophe in the title, asking a question about it, and verifying the PDF loaded.

![Screenshot 2024-05-07 at 2 37 20 PM](https://github.com/Azure-Samples/azure-search-openai-demo/assets/297042/b0f6f325-ef43-470b-b57f-dc3239d0597f)


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [X] The current tests all pass (`python -m pytest`).
- [X] I added tests that prove my fix is effective or that my feature works
- [X] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `python -m mypy` to check for type errors
- [X] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
