### PR TITLE
Disable key auth for Azure Document Intelligence

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -395,6 +395,7 @@ module documentIntelligence 'core/ai/cognitiveservices.bicep' = {
     kind: 'FormRecognizer'
     publicNetworkAccess: publicNetworkAccess
     location: documentIntelligenceResourceGroupLocation
+    disableLocalAuth: true
     tags: tags
     sku: {
       name: documentIntelligenceSkuName


### PR DESCRIPTION
## Purpose

This PRs disable key-based API access ("local auth") for Document Intelligence, which is preferred from a security standpoint. We have seen that developers have wanted to keep key access for their OpenAI accounts and have been asked to make it an option, should I also make this an option (via a bool parameter like enableDocIntelligenceKeys defaulting to false?)

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No - at least it shouldnt be for our core repo
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [x] I added tests that prove my fix is effective or that my feature works
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
