### PR TITLE
Fix overlap percentage calculation

### DIFF
--- a/app/backend/prepdocslib/textsplitter.py
+++ b/app/backend/prepdocslib/textsplitter.py
@@ -93,7 +93,7 @@ class SentenceTextSplitter(TextSplitter):
         self.max_section_length = DEFAULT_SECTION_LENGTH
         self.sentence_search_limit = 100
         self.max_tokens_per_section = max_tokens_per_section
-        self.section_overlap = self.max_section_length // DEFAULT_OVERLAP_PERCENT
+        self.section_overlap = int(self.max_section_length * DEFAULT_OVERLAP_PERCENT / 100)
         self.has_image_embeddings = has_image_embeddings
 
     def split_page_by_max_tokens(self, page_num: int, text: str) -> Generator[SplitPage, None, None]:

--- a/tests/test_sentencetextsplitter.py
+++ b/tests/test_sentencetextsplitter.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+
+import pytest
+
+from prepdocslib.textsplitter import SentenceTextSplitter
+
+
+@pytest.mark.parametrize(
+    "actual_percentage, expected_section_overlap",
+    [
+        (100, 1000),
+        (80, 800),
+        (10.75, 107),
+        (10, 100),
+        (0, 0),
+    ],
+)
+def test_sentence_text_splitter_initializes_overlap_correctly(
+    actual_percentage: float, expected_section_overlap: float
+):
+    with patch("prepdocslib.textsplitter.DEFAULT_OVERLAP_PERCENT", actual_percentage):
+        subject = SentenceTextSplitter(False)
+        assert subject.section_overlap == expected_section_overlap


### PR DESCRIPTION
## Purpose

Closes #1667.

This PR fixes the overlap calculation issue reported in #1667.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[x] No
```

## Type of change

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`) - some tests fail locally.
- [x] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines - some tests fail locally
- [x] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
