### PR TITLE
Remove powershell feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,6 @@
             "version": "18",
             "nodeGypDependencies": false
         },
-        "ghcr.io/devcontainers/features/powershell:1.1.0": {},
         "ghcr.io/devcontainers/features/azure-cli:1.0.8": {},
         "ghcr.io/azure/azure-dev/azd:latest": {}
     },


### PR DESCRIPTION
## Purpose

Fixes #1749 

The powershell feature is causing Codespace builds to break, seems related to https://github.com/PowerShell/PowerShell/issues/23975

I think we rarely need powershell inside the devcontainer, since you can use bash scripts there. I mostly use it when I'm testing what powershell scripts would do on a Windows machine, to avoid me having to open a DevBox for Windows.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes - Maybe, if developers are actually using powershell inside devcontainer/Codespace?
[ ] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

N/A