### PR TITLE
Set ACLs to Deny for storage

### DIFF
--- a/infra/core/storage/storage-account.bicep
+++ b/infra/core/storage/storage-account.bicep
@@ -26,10 +26,10 @@ param sku object = { name: 'Standard_LRS' }
 @allowed([ 'None', 'AzureServices' ])
 param bypass string = 'AzureServices'
 
-var networkAcls = {
+var networkAcls = (publicNetworkAccess == 'Enabled') ? {
   bypass: bypass
   defaultAction: 'Allow'
-}
+} : { defaultAction: 'Deny' }
 
 resource storage 'Microsoft.Storage/storageAccounts@2022-05-01' = {
   name: name


### PR DESCRIPTION
## Purpose

This resolves a security alert. We currently still have NetworkAcls:Allow even when public access is set to Disabled. This PR changes them to Deny in that case. 

I have tested this in my Vnet branch and I was able to view citations from inside the VM. I will now test with a non-Vnet branch and ensure nothing changes there.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

N/A Bicep only