### PR TITLE
Fix vite by adding host

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -7,7 +7,7 @@
     "node": ">=14.0.0"
   },
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host 127.0.0.1",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },


### PR DESCRIPTION
## Purpose

Fixes #1788 

The additional argument is necessary due to a vite/Docker interaction issue detailed in:
https://github.com/vitejs/vite/issues/16522

It's also possible to specify the host in vite.config.ts:
https://github.com/Azure-Samples/rag-postgres-openai-python/commit/966022375e9f999c36d7cce66aea24e9b0892e89

But this approach (in package.json) might be more obvious, if someone needs to change it.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

N/A