### PR TITLE
Add an optional seed parameter

### DIFF
--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -88,6 +88,7 @@ class ChatReadRetrieveReadApproach(ChatApproach):
         auth_claims: dict[str, Any],
         should_stream: bool = False,
     ) -> tuple[dict[str, Any], Coroutine[Any, Any, Union[ChatCompletion, AsyncStream[ChatCompletionChunk]]]]:
+        seed = overrides.get("seed", None)
         use_text_search = overrides.get("retrieval_mode") in ["text", "hybrid", None]
         use_vector_search = overrides.get("retrieval_mode") in ["vectors", "hybrid", None]
         use_semantic_ranker = True if overrides.get("semantic_ranker") else False
@@ -142,6 +143,7 @@ class ChatReadRetrieveReadApproach(ChatApproach):
             max_tokens=query_response_token_limit,  # Setting too low risks malformed JSON, setting too high may affect performance
             n=1,
             tools=tools,
+            seed=seed,
         )
 
         query_text = self.get_search_query(chat_completion, original_user_query)
@@ -237,5 +239,6 @@ class ChatReadRetrieveReadApproach(ChatApproach):
             max_tokens=response_token_limit,
             n=1,
             stream=should_stream,
+            seed=seed,
         )
         return (extra_info, chat_coroutine)

--- a/app/backend/approaches/chatreadretrievereadvision.py
+++ b/app/backend/approaches/chatreadretrievereadvision.py
@@ -89,6 +89,7 @@ class ChatReadRetrieveReadVisionApproach(ChatApproach):
         auth_claims: dict[str, Any],
         should_stream: bool = False,
     ) -> tuple[dict[str, Any], Coroutine[Any, Any, Union[ChatCompletion, AsyncStream[ChatCompletionChunk]]]]:
+        seed = overrides.get("seed", None)
         use_text_search = overrides.get("retrieval_mode") in ["text", "hybrid", None]
         use_vector_search = overrides.get("retrieval_mode") in ["vectors", "hybrid", None]
         use_semantic_ranker = True if overrides.get("semantic_ranker") else False
@@ -128,6 +129,7 @@ class ChatReadRetrieveReadVisionApproach(ChatApproach):
             temperature=0.0,  # Minimize creativity for search query generation
             max_tokens=query_response_token_limit,
             n=1,
+            seed=seed,
         )
 
         query_text = self.get_search_query(chat_completion, original_user_query)
@@ -241,5 +243,6 @@ class ChatReadRetrieveReadVisionApproach(ChatApproach):
             max_tokens=response_token_limit,
             n=1,
             stream=should_stream,
+            seed=seed,
         )
         return (extra_info, chat_coroutine)

--- a/app/backend/approaches/retrievethenread.py
+++ b/app/backend/approaches/retrievethenread.py
@@ -79,6 +79,7 @@ info4.pdf: In-network institutions include Overlake, Swedish and others in the r
         if not isinstance(q, str):
             raise ValueError("The most recent message content must be a string.")
         overrides = context.get("overrides", {})
+        seed = overrides.get("seed", None)
         auth_claims = context.get("auth_claims", {})
         use_text_search = overrides.get("retrieval_mode") in ["text", "hybrid", None]
         use_vector_search = overrides.get("retrieval_mode") in ["vectors", "hybrid", None]
@@ -131,6 +132,7 @@ info4.pdf: In-network institutions include Overlake, Swedish and others in the r
                 temperature=overrides.get("temperature", 0.3),
                 max_tokens=response_token_limit,
                 n=1,
+                seed=seed,
             )
         ).model_dump()
 

--- a/app/backend/approaches/retrievethenreadvision.py
+++ b/app/backend/approaches/retrievethenreadvision.py
@@ -80,6 +80,7 @@ class RetrieveThenReadVisionApproach(Approach):
             raise ValueError("The most recent message content must be a string.")
 
         overrides = context.get("overrides", {})
+        seed = overrides.get("seed", None)
         auth_claims = context.get("auth_claims", {})
         use_text_search = overrides.get("retrieval_mode") in ["text", "hybrid", None]
         use_vector_search = overrides.get("retrieval_mode") in ["vectors", "hybrid", None]
@@ -148,6 +149,7 @@ class RetrieveThenReadVisionApproach(Approach):
                 temperature=overrides.get("temperature", 0.3),
                 max_tokens=response_token_limit,
                 n=1,
+                seed=seed,
             )
         ).model_dump()
 

--- a/app/frontend/src/api/models.ts
+++ b/app/frontend/src/api/models.ts
@@ -21,6 +21,7 @@ export type ChatAppRequestOverrides = {
     semantic_ranker?: boolean;
     semantic_captions?: boolean;
     exclude_category?: string;
+    seed?: number;
     top?: number;
     temperature?: number;
     minimum_search_score?: number;

--- a/app/frontend/src/i18n/tooltips.ts
+++ b/app/frontend/src/i18n/tooltips.ts
@@ -5,6 +5,7 @@ export const toolTipText = {
         "Overrides the prompt used to generate the answer based on the question and search results. To append to existing prompt instead of replace whole prompt, start your prompt with '>>>'.",
     temperature:
         "Sets the temperature of the request to the LLM that generates the answer. Higher temperatures result in more creative responses, but they may be less grounded.",
+    seed: "Sets a seed to improve the reproducibility of the model's responses. The seed can be any integer.",
     searchScore:
         "Sets a minimum score for search results coming back from Azure AI search. The score range depends on whether you're using hybrid (default), vectors only, or text only.",
     rerankerScore:

--- a/app/frontend/src/pages/ask/Ask.tsx
+++ b/app/frontend/src/pages/ask/Ask.tsx
@@ -27,6 +27,7 @@ export function Component(): JSX.Element {
     const [promptTemplatePrefix, setPromptTemplatePrefix] = useState<string>("");
     const [promptTemplateSuffix, setPromptTemplateSuffix] = useState<string>("");
     const [temperature, setTemperature] = useState<number>(0.3);
+    const [seed, setSeed] = useState<number | null>(null);
     const [minimumRerankerScore, setMinimumRerankerScore] = useState<number>(0);
     const [minimumSearchScore, setMinimumSearchScore] = useState<number>(0);
     const [retrievalMode, setRetrievalMode] = useState<RetrievalMode>(RetrievalMode.Hybrid);
@@ -124,7 +125,8 @@ export function Component(): JSX.Element {
                         use_groups_security_filter: useGroupsSecurityFilter,
                         vector_fields: vectorFieldList,
                         use_gpt4v: useGPT4V,
-                        gpt4v_input: gpt4vInput
+                        gpt4v_input: gpt4vInput,
+                        ...(seed !== null ? { seed: seed } : {})
                     }
                 },
                 // AI Chat Protocol: Client must pass on any session state received from the server
@@ -146,6 +148,10 @@ export function Component(): JSX.Element {
 
     const onTemperatureChange = (_ev?: React.SyntheticEvent<HTMLElement, Event>, newValue?: string) => {
         setTemperature(parseFloat(newValue || "0"));
+    };
+
+    const onSeedChange = (_ev?: React.SyntheticEvent<HTMLElement, Event>, newValue?: string) => {
+        setSeed(parseInt(newValue || ""));
     };
 
     const onMinimumSearchScoreChange = (_ev?: React.SyntheticEvent<HTMLElement, Event>, newValue?: string) => {
@@ -206,6 +212,8 @@ export function Component(): JSX.Element {
     const promptTemplateFieldId = useId("promptTemplateField");
     const temperatureId = useId("temperature");
     const temperatureFieldId = useId("temperatureField");
+    const seedId = useId("seed");
+    const seedFieldId = useId("seedField");
     const searchScoreId = useId("searchScore");
     const searchScoreFieldId = useId("searchScoreField");
     const rerankerScoreId = useId("rerankerScore");
@@ -311,6 +319,19 @@ export function Component(): JSX.Element {
                     aria-labelledby={temperatureId}
                     onRenderLabel={(props: ITextFieldProps | undefined) => (
                         <HelpCallout labelId={temperatureId} fieldId={temperatureFieldId} helpText={toolTipText.temperature} label={props?.label} />
+                    )}
+                />
+
+                <TextField
+                    id={seedFieldId}
+                    className={styles.chatSettingsSeparator}
+                    label="Seed"
+                    type="text"
+                    defaultValue={seed?.toString() || ""}
+                    onChange={onSeedChange}
+                    aria-labelledby={seedId}
+                    onRenderLabel={(props: ITextFieldProps | undefined) => (
+                        <HelpCallout labelId={seedId} fieldId={seedFieldId} helpText={toolTipText.seed} label={props?.label} />
                     )}
                 />
 

--- a/app/frontend/src/pages/chat/Chat.tsx
+++ b/app/frontend/src/pages/chat/Chat.tsx
@@ -39,6 +39,7 @@ const Chat = () => {
     const [isConfigPanelOpen, setIsConfigPanelOpen] = useState(false);
     const [promptTemplate, setPromptTemplate] = useState<string>("");
     const [temperature, setTemperature] = useState<number>(0.3);
+    const [seed, setSeed] = useState<number | null>(null);
     const [minimumRerankerScore, setMinimumRerankerScore] = useState<number>(0);
     const [minimumSearchScore, setMinimumSearchScore] = useState<number>(0);
     const [retrieveCount, setRetrieveCount] = useState<number>(3);
@@ -173,7 +174,8 @@ const Chat = () => {
                         use_groups_security_filter: useGroupsSecurityFilter,
                         vector_fields: vectorFieldList,
                         use_gpt4v: useGPT4V,
-                        gpt4v_input: gpt4vInput
+                        gpt4v_input: gpt4vInput,
+                        ...(seed !== null ? { seed: seed } : {})
                     }
                 },
                 // AI Chat Protocol: Client must pass on any session state received from the server
@@ -237,6 +239,10 @@ const Chat = () => {
 
     const onTemperatureChange = (_ev?: React.SyntheticEvent<HTMLElement, Event>, newValue?: string) => {
         setTemperature(parseFloat(newValue || "0"));
+    };
+
+    const onSeedChange = (_ev?: React.SyntheticEvent<HTMLElement, Event>, newValue?: string) => {
+        setSeed(parseInt(newValue || ""));
     };
 
     const onMinimumSearchScoreChange = (_ev?: React.SyntheticEvent<HTMLElement, Event>, newValue?: string) => {
@@ -309,6 +315,8 @@ const Chat = () => {
     const promptTemplateFieldId = useId("promptTemplateField");
     const temperatureId = useId("temperature");
     const temperatureFieldId = useId("temperatureField");
+    const seedId = useId("seed");
+    const seedFieldId = useId("seedField");
     const searchScoreId = useId("searchScore");
     const searchScoreFieldId = useId("searchScoreField");
     const rerankerScoreId = useId("rerankerScore");
@@ -475,6 +483,19 @@ const Chat = () => {
                         aria-labelledby={temperatureId}
                         onRenderLabel={(props: ITextFieldProps | undefined) => (
                             <HelpCallout labelId={temperatureId} fieldId={temperatureFieldId} helpText={toolTipText.temperature} label={props?.label} />
+                        )}
+                    />
+
+                    <TextField
+                        id={seedFieldId}
+                        className={styles.chatSettingsSeparator}
+                        label="Seed"
+                        type="text"
+                        defaultValue={seed?.toString() || ""}
+                        onChange={onSeedChange}
+                        aria-labelledby={seedId}
+                        onRenderLabel={(props: ITextFieldProps | undefined) => (
+                            <HelpCallout labelId={seedId} fieldId={seedFieldId} helpText={toolTipText.seed} label={props?.label} />
                         )}
                     />
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,6 +182,7 @@ def mock_openai_chatcompletion(monkeypatch):
     async def mock_acreate(*args, **kwargs):
         messages = kwargs["messages"]
         last_question = messages[-1]["content"]
+        assert kwargs.get("seed") is None
         if last_question == "Generate search query for: What is the capital of France?":
             answer = "capital of France"
         elif last_question == "Generate search query for: Are interest rates high?":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,9 +180,11 @@ def mock_openai_chatcompletion(monkeypatch):
                 raise StopAsyncIteration
 
     async def mock_acreate(*args, **kwargs):
+        # The only two possible values for seed:
+        assert kwargs.get("seed") is None or kwargs.get("seed") == 42
+
         messages = kwargs["messages"]
         last_question = messages[-1]["content"]
-        assert kwargs.get("seed") is None
         if last_question == "Generate search query for: What is the capital of France?":
             answer = "capital of France"
         elif last_question == "Generate search query for: Are interest rates high?":

--- a/tests/snapshots/test_app/test_chat_seed/client0/result.json
+++ b/tests/snapshots/test_app/test_chat_seed/client0/result.json
@@ -1,0 +1,83 @@
+{
+    "context": {
+        "data_points": {
+            "text": [
+                "Benefit_Options-2.pdf: There is a whistleblower policy."
+            ]
+        },
+        "thoughts": [
+            {
+                "description": [
+                    "{'role': 'system', 'content': \"Below is a history of the conversation so far, and a new question asked by the user that needs to be answered by searching in a knowledge base.\\n    You have access to Azure AI Search index with 100's of documents.\\n    Generate a search query based on the conversation and the new question.\\n    Do not include cited source filenames and document names e.g info.txt or doc.pdf in the search query terms.\\n    Do not include any text inside [] or <<>> in the search query terms.\\n    Do not include any special characters like '+'.\\n    If the question is not in English, translate the question to English before generating the search query.\\n    If you cannot generate a search query, return just the number 0.\\n    \"}",
+                    "{'role': 'user', 'content': 'How did crypto do last year?'}",
+                    "{'role': 'assistant', 'content': 'Summarize Cryptocurrency Market Dynamics from last year'}",
+                    "{'role': 'user', 'content': 'What are my health plans?'}",
+                    "{'role': 'assistant', 'content': 'Show available health plans'}",
+                    "{'role': 'user', 'content': 'Generate search query for: What is the capital of France?'}"
+                ],
+                "props": {
+                    "model": "gpt-35-turbo"
+                },
+                "title": "Prompt to generate search query"
+            },
+            {
+                "description": "capital of France",
+                "props": {
+                    "filter": null,
+                    "top": 3,
+                    "use_semantic_captions": false,
+                    "use_semantic_ranker": false,
+                    "use_text_search": true,
+                    "use_vector_search": true
+                },
+                "title": "Search using generated search query"
+            },
+            {
+                "description": [
+                    {
+                        "captions": [
+                            {
+                                "additional_properties": {},
+                                "highlights": [],
+                                "text": "Caption: A whistleblower policy."
+                            }
+                        ],
+                        "category": null,
+                        "content": "There is a whistleblower policy.",
+                        "embedding": null,
+                        "groups": null,
+                        "id": "file-Benefit_Options_pdf-42656E656669745F4F7074696F6E732E706466-page-2",
+                        "imageEmbedding": null,
+                        "oids": null,
+                        "reranker_score": 3.4577205181121826,
+                        "score": 0.03279569745063782,
+                        "sourcefile": "Benefit_Options.pdf",
+                        "sourcepage": "Benefit_Options-2.pdf"
+                    }
+                ],
+                "props": null,
+                "title": "Search results"
+            },
+            {
+                "description": [
+                    "{'role': 'system', 'content': \"Assistant helps the company employees with their healthcare plan questions, and questions about the employee handbook. Be brief in your answers.\\n        Answer ONLY with the facts listed in the list of sources below. If there isn't enough information below, say you don't know. Do not generate answers that don't use the sources below. If asking a clarifying question to the user would help, ask the question.\\n        For tabular information return it as an html table. Do not return markdown format. If the question is not in English, answer in the language used in the question.\\n        Each source has a name followed by colon and the actual information, always include the source name for each fact you use in the response. Use square brackets to reference the source, for example [info1.txt]. Don't combine sources, list each source separately, for example [info1.txt][info2.pdf].\\n        \\n        \\n        \"}",
+                    "{'role': 'user', 'content': 'What is the capital of France?\\n\\nSources:\\nBenefit_Options-2.pdf: There is a whistleblower policy.'}"
+                ],
+                "props": {
+                    "model": "gpt-35-turbo"
+                },
+                "title": "Prompt to generate answer"
+            }
+        ]
+    },
+    "finish_reason": "stop",
+    "index": 0,
+    "logprobs": null,
+    "message": {
+        "content": "The capital of France is Paris. [Benefit_Options-2.pdf].",
+        "function_call": null,
+        "role": "assistant",
+        "tool_calls": null
+    },
+    "session_state": null
+}

--- a/tests/snapshots/test_app/test_chat_seed/client1/result.json
+++ b/tests/snapshots/test_app/test_chat_seed/client1/result.json
@@ -1,0 +1,85 @@
+{
+    "context": {
+        "data_points": {
+            "text": [
+                "Benefit_Options-2.pdf: There is a whistleblower policy."
+            ]
+        },
+        "thoughts": [
+            {
+                "description": [
+                    "{'role': 'system', 'content': \"Below is a history of the conversation so far, and a new question asked by the user that needs to be answered by searching in a knowledge base.\\n    You have access to Azure AI Search index with 100's of documents.\\n    Generate a search query based on the conversation and the new question.\\n    Do not include cited source filenames and document names e.g info.txt or doc.pdf in the search query terms.\\n    Do not include any text inside [] or <<>> in the search query terms.\\n    Do not include any special characters like '+'.\\n    If the question is not in English, translate the question to English before generating the search query.\\n    If you cannot generate a search query, return just the number 0.\\n    \"}",
+                    "{'role': 'user', 'content': 'How did crypto do last year?'}",
+                    "{'role': 'assistant', 'content': 'Summarize Cryptocurrency Market Dynamics from last year'}",
+                    "{'role': 'user', 'content': 'What are my health plans?'}",
+                    "{'role': 'assistant', 'content': 'Show available health plans'}",
+                    "{'role': 'user', 'content': 'Generate search query for: What is the capital of France?'}"
+                ],
+                "props": {
+                    "deployment": "test-chatgpt",
+                    "model": "gpt-35-turbo"
+                },
+                "title": "Prompt to generate search query"
+            },
+            {
+                "description": "capital of France",
+                "props": {
+                    "filter": null,
+                    "top": 3,
+                    "use_semantic_captions": false,
+                    "use_semantic_ranker": false,
+                    "use_text_search": true,
+                    "use_vector_search": true
+                },
+                "title": "Search using generated search query"
+            },
+            {
+                "description": [
+                    {
+                        "captions": [
+                            {
+                                "additional_properties": {},
+                                "highlights": [],
+                                "text": "Caption: A whistleblower policy."
+                            }
+                        ],
+                        "category": null,
+                        "content": "There is a whistleblower policy.",
+                        "embedding": null,
+                        "groups": null,
+                        "id": "file-Benefit_Options_pdf-42656E656669745F4F7074696F6E732E706466-page-2",
+                        "imageEmbedding": null,
+                        "oids": null,
+                        "reranker_score": 3.4577205181121826,
+                        "score": 0.03279569745063782,
+                        "sourcefile": "Benefit_Options.pdf",
+                        "sourcepage": "Benefit_Options-2.pdf"
+                    }
+                ],
+                "props": null,
+                "title": "Search results"
+            },
+            {
+                "description": [
+                    "{'role': 'system', 'content': \"Assistant helps the company employees with their healthcare plan questions, and questions about the employee handbook. Be brief in your answers.\\n        Answer ONLY with the facts listed in the list of sources below. If there isn't enough information below, say you don't know. Do not generate answers that don't use the sources below. If asking a clarifying question to the user would help, ask the question.\\n        For tabular information return it as an html table. Do not return markdown format. If the question is not in English, answer in the language used in the question.\\n        Each source has a name followed by colon and the actual information, always include the source name for each fact you use in the response. Use square brackets to reference the source, for example [info1.txt]. Don't combine sources, list each source separately, for example [info1.txt][info2.pdf].\\n        \\n        \\n        \"}",
+                    "{'role': 'user', 'content': 'What is the capital of France?\\n\\nSources:\\nBenefit_Options-2.pdf: There is a whistleblower policy.'}"
+                ],
+                "props": {
+                    "deployment": "test-chatgpt",
+                    "model": "gpt-35-turbo"
+                },
+                "title": "Prompt to generate answer"
+            }
+        ]
+    },
+    "finish_reason": "stop",
+    "index": 0,
+    "logprobs": null,
+    "message": {
+        "content": "The capital of France is Paris. [Benefit_Options-2.pdf].",
+        "function_call": null,
+        "role": "assistant",
+        "tool_calls": null
+    },
+    "session_state": null
+}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -584,6 +584,22 @@ async def test_chat_prompt_template_concat(client, snapshot):
 
 
 @pytest.mark.asyncio
+async def test_chat_seed(client, snapshot):
+    response = await client.post(
+        "/chat",
+        json={
+            "messages": [{"content": "What is the capital of France?", "role": "user"}],
+            "context": {
+                "overrides": {"seed": 42},
+            },
+        },
+    )
+    assert response.status_code == 200
+    result = await response.get_json()
+    snapshot.assert_match(json.dumps(result, indent=4), "result.json")
+
+
+@pytest.mark.asyncio
 async def test_chat_hybrid(client, snapshot):
     response = await client.post(
         "/chat",


### PR DESCRIPTION
## Purpose

This adds a seed parameter. This was a bit tricky as we need to send in null if no seed is desired. I did that by only sending the seed parameter over the wire if its explicitly set in the frontend, and defaulting the value to None in Python.

Fixes #1344

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[X] Yes - New setting and screenshot needed.
[ ] No
```

## Type of change

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [x] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
