### PR TITLE
Rename Azure OpenAI key environment variable

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -541,8 +541,8 @@ async def setup_clients():
             if not AZURE_OPENAI_SERVICE:
                 raise ValueError("AZURE_OPENAI_SERVICE must be set when OPENAI_HOST is azure")
             endpoint = f"https://{AZURE_OPENAI_SERVICE}.openai.azure.com"
-        if api_key := os.getenv("AZURE_OPENAI_API_KEY"):
-            current_app.logger.info("AZURE_OPENAI_API_KEY found, using as value for api_key for Azure OpenAI client")
+        if api_key := os.getenv("AZURE_OPENAI_API_KEY_OVERRIDE"):
+            current_app.logger.info("AZURE_OPENAI_API_KEY_OVERRIDE found, using as api_key for Azure OpenAI client")
             openai_client = AsyncAzureOpenAI(api_version=api_version, azure_endpoint=endpoint, api_key=api_key)
         else:
             current_app.logger.info("Using Azure credential (passwordless authentication) for Azure OpenAI client")

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -307,7 +307,7 @@ module backend 'core/host/appservice.bicep' = {
       AZURE_OPENAI_EMB_DEPLOYMENT: embedding.deploymentName
       AZURE_OPENAI_GPT4V_DEPLOYMENT: useGPT4V ? gpt4vDeploymentName : ''
       AZURE_OPENAI_API_VERSION: azureOpenAiApiVersion
-      AZURE_OPENAI_API_KEY: azureOpenAiApiKey
+      AZURE_OPENAI_API_KEY_OVERRIDE: azureOpenAiApiKey
       AZURE_OPENAI_CUSTOM_URL: azureOpenAiCustomUrl
       // Used only with non-Azure OpenAI deployments
       OPENAI_API_KEY: openAiApiKey

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -126,7 +126,7 @@
       "value": "${AZURE_OPENAI_API_VERSION}"
     },
     "azureOpenAiApiKey":{
-      "value": "${AZURE_OPENAI_API_KEY}"
+      "value": "${AZURE_OPENAI_API_KEY_OVERRIDE}"
     },
     "openAiApiKey": {
       "value": "${OPENAI_API_KEY}"

--- a/scripts/prepdocs.ps1
+++ b/scripts/prepdocs.ps1
@@ -65,8 +65,8 @@ if ($env:USE_FEATURE_INT_VECTORIZATION) {
   $integratedVectorizationArg = "--useintvectorization $env:USE_FEATURE_INT_VECTORIZATION"
 }
 
-if ($env:AZURE_OPENAI_API_KEY) {
-  $openaiApiKeyArg = "--openaikey $env:AZURE_OPENAI_API_KEY"
+if ($env:AZURE_OPENAI_API_KEY_OVERRIDE) {
+  $openaiApiKeyArg = "--openaikey $env:AZURE_OPENAI_API_KEY_OVERRIDE"
 } elseif ($env:OPENAI_API_KEY) {
   $openaiApiKeyArg = "--openaikey $env:OPENAI_API_KEY"
 }

--- a/scripts/prepdocs.sh
+++ b/scripts/prepdocs.sh
@@ -63,8 +63,8 @@ if [ -n "$USE_FEATURE_INT_VECTORIZATION" ]; then
   integratedVectorizationArg="--useintvectorization $USE_FEATURE_INT_VECTORIZATION"
 fi
 
-if [ -n "$AZURE_OPENAI_API_KEY" ]; then
-  openAiApiKeyArg="--openaikey $AZURE_OPENAI_API_KEY"
+if [ -n "$AZURE_OPENAI_API_KEY_OVERRIDE" ]; then
+  openAiApiKeyArg="--openaikey $AZURE_OPENAI_API_KEY_OVERRIDE"
 elif [ -n "$OPENAI_API_KEY" ]; then
   openAiApiKeyArg="--openaikey $OPENAI_API_KEY"
 fi

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -33,7 +33,7 @@ async def test_app_local_openai(monkeypatch, minimal_env):
 async def test_app_azure_custom_key(monkeypatch, minimal_env):
     monkeypatch.setenv("OPENAI_HOST", "azure_custom")
     monkeypatch.setenv("AZURE_OPENAI_CUSTOM_URL", "http://azureapi.com/api/v1")
-    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "azure-api-key")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY_OVERRIDE", "azure-api-key")
 
     quart_app = app.create_app()
     async with quart_app.test_app():


### PR DESCRIPTION
## Purpose

Since adding AZURE_OPENAI_API_KEY as an optional env variable several months ago, many developers have had errors when running and deploying the app, due to that variable existing from other tutorials/templates. This PR changes the variable to a much more unique name.
Fortunately, I never documented it in this repo, since that change was to support our use of the Azure OpenAI Proxy in workshops, so I do not believe many developers are using it for production. I will note in release notes as a backwards compatible change.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[X] Yes - for any developer who'd been relying on it. Should be minimal given its 2 months old and undocumented.
[ ] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No - But I do need to update https://github.com/Azure-Samples/ai-app-templates-workshop once merged
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [x] I added tests that prove my fix is effective or that my feature works
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
