### PR TITLE
Reduce cost by defaulting to basic tier of search service

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ The repo includes sample data so it's ready to try end to end. In this sample ap
 ### Cost estimation
 
 Pricing varies per region and usage, so it isn't possible to predict exact costs for your usage.
-However, you can try the [Azure pricing calculator](https://azure.com/e/d18187516e9e421e925b3b311eec8aae) for the resources below.
+However, you can try the [Azure pricing calculator](https://azure.com/e/a87a169b256e43c089015fda8182ca87) for the resources below.
 
 - Azure App Service: Basic Tier with 1 CPU core, 1.75 GB RAM. Pricing per hour. [Pricing](https://azure.microsoft.com/pricing/details/app-service/linux/)
 - Azure OpenAI: Standard tier, GPT and Ada models. Pricing per 1K tokens used, and at least 1K tokens are used per question. [Pricing](https://azure.microsoft.com/pricing/details/cognitive-services/openai-service/)
 - Azure AI Document Intelligence: SO (Standard) tier using pre-built layout. Pricing per document page, sample documents have 261 pages total. [Pricing](https://azure.microsoft.com/pricing/details/form-recognizer/)
-- Azure AI Search: Standard tier, 1 replica, free level of semantic search. Pricing per hour. [Pricing](https://azure.microsoft.com/pricing/details/search/)
+- Azure AI Search: Basic tier, 1 replica, free level of semantic search. Pricing per hour. [Pricing](https://azure.microsoft.com/pricing/details/search/)
 - Azure Blob Storage: Standard tier with ZRS (Zone-redundant storage). Pricing per storage and read operations. [Pricing](https://azure.microsoft.com/pricing/details/storage/blobs/)
 - Azure Monitor: Pay-as-you-go tier. Costs based on data ingested. [Pricing](https://azure.microsoft.com/pricing/details/monitor/)
 

--- a/docs/productionizing.md
+++ b/docs/productionizing.md
@@ -37,16 +37,36 @@ which you can specify using the `sku` property under the `storage` module in `in
 
 ### Azure AI Search
 
-The default search service uses the `Standard` SKU
-with the free semantic search option, which gives you 1000 free queries a month.
-Assuming your app will experience more than 1000 questions, you should either change `semanticSearch`
-to "standard" or disable semantic search entirely in the `/app/backend/approaches` files.
-If you see errors about search service capacity being exceeded, you may find it helpful to increase
+The default search service uses the "Basic" SKU
+with the free semantic ranker option, which gives you 1000 free queries a month.
+After 1000 queries, you will get an error message about exceeding the semantic ranker free capacity.
+
+* Assuming your app will experience more than 1000 questions per month,
+  you should upgrade the semantic ranker SKU from "free" to "standard" SKU:
+
+  ```shell
+  azd env set AZURE_SEARCH_SEMANTIC_RANKER standard
+  ```
+
+  Or disable semantic search entirely:
+
+  ```shell
+  azd env set AZURE_SEARCH_SEMANTIC_RANKER disabled
+  ```
+
+* The search service can handle fairly large indexes, but it does have per-SKU limits on storage sizes, maximum vector dimensions, etc. You may want to upgrade the SKU to either a Standard or Storage Optimized SKU, depending on your expected load.
+However, you [cannot change the SKU](https://learn.microsoft.com/azure/search/search-sku-tier#tier-upgrade-or-downgrade) of an existing search service, so you will need to re-index the data or manually copy it over.
+You can change the SKU by setting the `AZURE_SEARCH_SERVICE_SKU` azd environment variable to [an allowed SKU](https://learn.microsoft.com/azure/templates/microsoft.search/searchservices?pivots=deployment-language-bicep#sku).
+
+  ```shell
+  azd env set AZURE_SEARCH_SERVICE_SKU standard
+  ```
+
+  See the [Azure AI Search service limits documentation](https://learn.microsoft.com/azure/search/search-limits-quotas-capacity) for more details.
+
+* If you see errors about search service capacity being exceeded, you may find it helpful to increase
 the number of replicas by changing `replicaCount` in `infra/core/search/search-services.bicep`
 or manually scaling it from the Azure Portal.
-
-The search service can handle fairly large indexes, but it does have per-SKU limits on storage sizes, maximum vector dimensions, etc.
-See the [service limits document](https://learn.microsoft.com/azure/search/search-limits-quotas-capacity) for more details.
 
 ### Azure App Service
 

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -60,7 +60,7 @@
       "value": "${AZURE_SEARCH_SERVICE_LOCATION}"
     },
     "searchServiceSkuName": {
-      "value": "${AZURE_SEARCH_SERVICE_SKU=standard}"
+      "value": "${AZURE_SEARCH_SERVICE_SKU=basic}"
     },
     "searchQueryLanguage": {
       "value": "${AZURE_SEARCH_QUERY_LANGUAGE=en-us}"


### PR DESCRIPTION
## Purpose

This PR makes the default deploy cheaper by using the basic tier of search service.
The main drawback of this is that you can't change tiers of existing search services, so:
1) Anyone who is updating to this code will need to explicitly set their sku to standard, via azd env set AZURE_SEARCH_SERVICE_SKU standard
2) Anyone who starts off with basic and wants to upgrade skus will have to either re-index their data ($$) or copy their data over (there are scripts to do this, but they take some effort to run)

However, we are trying to reduce default costs of our templates, so that developers have less surprises in their bills.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[X] Yes - See note above
[ ] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: $$
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

N/A

I am doing test deploys on existing environments and will also do a new environment.