### PR TITLE
azure.yaml improvements: remoteBuild option, prepackage for App Service

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -9,8 +9,23 @@ services:
     language: py
     # Please check docs/azure_container_apps.md for more information on how to deploy to Azure Container Apps
     # host: containerapp
+    # docker:
+    #  remoteBuild: true
     host: appservice
     hooks:
+      # This hook is called when App Service is the host
+      prepackage:
+        windows:
+          shell: pwsh
+          run:  cd ../frontend;npm install;npm run build
+          interactive: false
+          continueOnError: false
+        posix:
+          shell: sh
+          run:  cd ../frontend;npm install;npm run build
+          interactive: false
+          continueOnError: false
+      # This hook is called when Azure Container Apps is the host
       prebuild:
         windows:
           shell: pwsh


### PR DESCRIPTION
## Purpose

When we added optional ACA deployment, we changed `prepackage` to `prebuild`, but azd us not calling prebuild for App Service deployments, so its not building the static folder. So App Service deployments only work if you've somehow built that static folder otherwise, like by having run the local server before the deploy. 

FYI @1yefuwang1 


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
