### PR TITLE
Configure GlobalStandard as default deployment sku for gpt-4o

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
     "forwardPorts": [
         50505
     ],
-    "postCreateCommand": "",
+    "postCreateCommand": "python3 -m pip install -r requirements-dev.txt",
     "remoteUser": "vscode",
     "hostRequirements": {
         "memory": "8gb"

--- a/azure.yaml
+++ b/azure.yaml
@@ -132,3 +132,12 @@ hooks:
         run: ./scripts/auth_update.sh;./scripts/prepdocs.sh
         interactive: true
         continueOnError: false
+    predown:
+      windows:
+        shell: pwsh
+        run: ./scripts/pre-down.ps1
+        continueOnError: true
+      posix:
+        shell: sh
+        run: ./scripts/pre-down.sh
+        continueOnError: true

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -57,7 +57,7 @@ param speechServiceResourceGroupName string = ''
 param speechServiceLocation string = ''
 param speechServiceName string = ''
 param speechServiceSkuName string // Set in main.parameters.json
-param useGPT4V bool = false
+param useGPT4V bool = true
 
 @description('Location for the OpenAI resource group')
 @allowed([
@@ -110,6 +110,7 @@ param chatGptModelName string = ''
 param chatGptDeploymentName string = ''
 param chatGptDeploymentVersion string = ''
 param chatGptDeploymentCapacity int = 0
+param chatGptDeploymentSkuName string = ''
 var chatGpt = {
   modelName: !empty(chatGptModelName)
     ? chatGptModelName
@@ -117,6 +118,7 @@ var chatGpt = {
   deploymentName: !empty(chatGptDeploymentName) ? chatGptDeploymentName : 'chat'
   deploymentVersion: !empty(chatGptDeploymentVersion) ? chatGptDeploymentVersion : '0613'
   deploymentCapacity: chatGptDeploymentCapacity != 0 ? chatGptDeploymentCapacity : 30
+  deploymentSkuName: !empty(chatGptDeploymentSkuName) ? chatGptDeploymentSkuName : 'Standard'
 }
 
 param embeddingModelName string = ''
@@ -124,11 +126,13 @@ param embeddingDeploymentName string = ''
 param embeddingDeploymentVersion string = ''
 param embeddingDeploymentCapacity int = 0
 param embeddingDimensions int = 0
+param embeddingDeploymentSkuName string = ''
 var embedding = {
   modelName: !empty(embeddingModelName) ? embeddingModelName : 'text-embedding-ada-002'
   deploymentName: !empty(embeddingDeploymentName) ? embeddingDeploymentName : 'embedding'
   deploymentVersion: !empty(embeddingDeploymentVersion) ? embeddingDeploymentVersion : '2'
   deploymentCapacity: embeddingDeploymentCapacity != 0 ? embeddingDeploymentCapacity : 30
+  deploymentSkuName: !empty(embeddingDeploymentSkuName) ? embeddingDeploymentSkuName : 'Standard'
   dimensions: embeddingDimensions != 0 ? embeddingDimensions : 1536
 }
 
@@ -136,6 +140,7 @@ param gpt4vModelName string = 'gpt-4o'
 param gpt4vDeploymentName string = 'gpt-4o'
 param gpt4vModelVersion string = '2024-05-13'
 param gpt4vDeploymentCapacity int = 10
+param gpt4vDeploymentSkuName string = 'GlobalStandard'
 
 param tenantId string = tenant().tenantId
 param authTenantId string = ''
@@ -453,7 +458,7 @@ var defaultOpenAiDeployments = [
       version: chatGpt.deploymentVersion
     }
     sku: {
-      name: 'Standard'
+      name: chatGpt.deploymentSkuName
       capacity: chatGpt.deploymentCapacity
     }
   }
@@ -465,7 +470,7 @@ var defaultOpenAiDeployments = [
       version: embedding.deploymentVersion
     }
     sku: {
-      name: 'Standard'
+      name: embedding.deploymentSkuName
       capacity: embedding.deploymentCapacity
     }
   }
@@ -483,7 +488,7 @@ var openAiDeployments = concat(
             version: gpt4vModelVersion
           }
           sku: {
-            name: 'Standard'
+            name: gpt4vDeploymentSkuName
             capacity: gpt4vDeploymentCapacity
           }
         }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -57,7 +57,7 @@ param speechServiceResourceGroupName string = ''
 param speechServiceLocation string = ''
 param speechServiceName string = ''
 param speechServiceSkuName string // Set in main.parameters.json
-param useGPT4V bool = true
+param useGPT4V bool = false
 
 @description('Location for the OpenAI resource group')
 @allowed([

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -101,6 +101,9 @@
     "chatGptDeploymentCapacity":{
       "value": "${AZURE_OPENAI_CHATGPT_DEPLOYMENT_CAPACITY}"
     },
+    "chatGptDeploymentSkuName":{
+      "value": "${AZURE_OPENAI_CHATGPT_DEPLOYMENT_SKU=Standard}"
+    },
     "embeddingModelName":{
       "value": "${AZURE_OPENAI_EMB_MODEL_NAME}"
     },
@@ -113,11 +116,26 @@
     "embeddingDeploymentCapacity":{
       "value": "${AZURE_OPENAI_EMB_DEPLOYMENT_CAPACITY}"
     },
+    "embeddingDeploymentSkuName":{
+      "value": "${AZURE_OPENAI_EMB_DEPLOYMENT_SKU=Standard}"
+    },
     "embeddingDimensions": {
       "value": "${AZURE_OPENAI_EMB_DIMENSIONS}"
     },
+    "gpt4vModelName": {
+      "value": "${AZURE_OPENAI_GPT4V_MODEL_NAME=gpt-4o}"
+    },
+    "gpt4vDeploymentName": {
+      "value": "${AZURE_OPENAI_GPT4V_DEPLOYMENT=gpt-4o}"
+    },
+    "gpt4vDeploymentVersion":{
+      "value": "${AZURE_OPENAI_GPT4V_DEPLOYMENT_VERSION=2024-05-13}"
+    },
     "gpt4vDeploymentCapacity":{
       "value": "${AZURE_OPENAI_GPT4V_DEPLOYMENT_CAPACITY=10}"
+    },
+    "gpt4vDeploymentSkuName":{
+      "value": "${AZURE_OPENAI_GPT4V_DEPLOYMENT_SKU=GlobalStandard}"
     },
     "openAiHost": {
       "value": "${OPENAI_HOST=azure}"
@@ -153,7 +171,7 @@
       "value": "${USE_VECTORS=true}"
     },
     "useGPT4V": {
-      "value": "${USE_GPT4V=false}"
+      "value": "${USE_GPT4V=true}"
     },
     "enableLanguagePicker": {
       "value": "${ENABLE_LANGUAGE_PICKER=false}"

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -171,7 +171,7 @@
       "value": "${USE_VECTORS=true}"
     },
     "useGPT4V": {
-      "value": "${USE_GPT4V=true}"
+      "value": "${USE_GPT4V=false}"
     },
     "enableLanguagePicker": {
       "value": "${ENABLE_LANGUAGE_PICKER=false}"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 -r app/backend/requirements.txt
+azure-mgmt-cognitiveservices
 ruff
 black
 pytest

--- a/scripts/pre-down.ps1
+++ b/scripts/pre-down.ps1
@@ -1,0 +1,10 @@
+# Get the directory of the current script
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+
+# Load environment variables from azd env
+$subscriptionId = azd env get-value AZURE_SUBSCRIPTION_ID
+$resourceName = azd env get-value AZURE_OPENAI_SERVICE
+$resourceGroup = azd env get-value AZURE_OPENAI_RESOURCE_GROUP
+
+# Run the Python script with the retrieved values
+python "$scriptDir/pre-down.py" --subscription-id $subscriptionId --resource-name $resourceName --resource-group $resourceGroup

--- a/scripts/pre-down.py
+++ b/scripts/pre-down.py
@@ -1,0 +1,32 @@
+import argparse
+
+from azure.identity import DefaultAzureCredential
+from azure.mgmt.cognitiveservices import CognitiveServicesManagementClient
+
+# Set up argument parsing
+parser = argparse.ArgumentParser(description="Delete an Azure OpenAI deployment.")
+parser.add_argument("--resource-name", required=True, help="The name of the Azure OpenAI resource.")
+parser.add_argument("--resource-group", required=True, help="The name of the Azure resource group.")
+parser.add_argument("--subscription-id", required=True, help="The Azure subscription ID.")
+
+args = parser.parse_args()
+
+# Authenticate using DefaultAzureCredential
+credential = DefaultAzureCredential()
+
+# Initialize the Cognitive Services client
+client = CognitiveServicesManagementClient(credential, subscription_id=args.subscription_id)
+
+# List all deployments
+deployments = client.deployments.list(
+    resource_group_name=args.resource_group, account_name=args.resource_name
+)
+
+# Delete each deployment and wait for the operation to complete
+for deployment in deployments:
+    deployment_name = deployment.name
+    poller = client.deployments.begin_delete(
+        resource_group_name=args.resource_group, account_name=args.resource_name, deployment_name=deployment_name
+    )
+    poller.result()
+    print(f"Deployment {deployment_name} deleted successfully.")

--- a/scripts/pre-down.py
+++ b/scripts/pre-down.py
@@ -25,6 +25,8 @@ deployments = client.deployments.list(
 # Delete each deployment and wait for the operation to complete
 for deployment in deployments:
     deployment_name = deployment.name
+    if not deployment_name:
+        continue
     poller = client.deployments.begin_delete(
         resource_group_name=args.resource_group, account_name=args.resource_name, deployment_name=deployment_name
     )

--- a/scripts/pre-down.py
+++ b/scripts/pre-down.py
@@ -18,9 +18,7 @@ credential = DefaultAzureCredential()
 client = CognitiveServicesManagementClient(credential, subscription_id=args.subscription_id)
 
 # List all deployments
-deployments = client.deployments.list(
-    resource_group_name=args.resource_group, account_name=args.resource_name
-)
+deployments = client.deployments.list(resource_group_name=args.resource_group, account_name=args.resource_name)
 
 # Delete each deployment and wait for the operation to complete
 for deployment in deployments:

--- a/scripts/pre-down.sh
+++ b/scripts/pre-down.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Get the directory of the current script
+script_dir=$(dirname "$0")
+
+# Load environment variables from azd env
+subscription_id=$(azd env get-value AZURE_SUBSCRIPTION_ID)
+resource_name=$(azd env get-value AZURE_OPENAI_SERVICE)
+resource_group=$(azd env get-value AZURE_OPENAI_RESOURCE_GROUP)
+
+# Run the Python script with the retrieved values
+python "$script_dir/pre-down.py" --subscription-id $subscription_id --resource-name $resource_name --resource-group $resource_group


### PR DESCRIPTION
## Purpose

This PR is proposed to configure the GlobalStandard as the default deployment sku for the GPT-4o model.
GPT35-turbo and embedding remains Standard since they are not supported by the GlobalStandard sku.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
