### PR TITLE
 Fix scrolling bar issue for long content in chat UI

### DIFF
--- a/app/frontend/src/pages/chat/Chat.module.css
+++ b/app/frontend/src/pages/chat/Chat.module.css
@@ -47,10 +47,10 @@
     width: 100%;
     overflow-y: auto;
     padding: 0 2rem;
-    max-width: 80vw;
     display: flex;
     flex-direction: column;
-    box-sizing: border-box;
+    resize: horizontal;
+    min-width: 50vw;
 }
 
 .chatMessageGpt {
@@ -77,7 +77,7 @@
 .chatAnalysisPanel {
     flex: 1;
     overflow-y: auto;
-    max-height: 89vh;
+    max-height: 85vh;
     margin-left: 1.25rem;
     margin-right: 1.25rem;
 }

--- a/app/frontend/src/pages/chat/Chat.module.css
+++ b/app/frontend/src/pages/chat/Chat.module.css
@@ -46,10 +46,11 @@
     max-height: 64rem;
     width: 100%;
     overflow-y: auto;
-    padding-left: 15vw;
-    padding-right: 15vw;
+    padding: 0 2rem;
+    max-width: 80vw;
     display: flex;
     flex-direction: column;
+    box-sizing: border-box;
 }
 
 .chatMessageGpt {

--- a/app/frontend/src/pages/chat/Chat.module.css
+++ b/app/frontend/src/pages/chat/Chat.module.css
@@ -16,6 +16,7 @@
     flex-direction: column;
     align-items: center;
     width: 100%;
+    max-height: calc(100vh - 10rem);
 }
 
 .chatEmptyState {
@@ -43,11 +44,10 @@
 .chatMessageStream {
     flex-grow: 1;
     max-height: 64rem;
-    max-width: 64.25rem;
     width: 100%;
     overflow-y: auto;
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-left: 15vw;
+    padding-right: 15vw;
     display: flex;
     flex-direction: column;
 }


### PR DESCRIPTION
limit .chatContainer height and expand chatMessageStream

## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
fix #2002 

![image](https://github.com/user-attachments/assets/039418ec-ac70-4036-900b-8342061fa1bb)

prevent the outside scrolling bar by limiting the total height.

extented the chatMessageStream to width 100%, and use padding to constrain the chat messages in center. (in order to allow user to scroll in wide range)

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?


```
[ ] Yes
[x] No, just css style change
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[x] No
```

## Type of change

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [x] I added tests that prove my fix is effective or that my feature works
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
