### PR TITLE
Add needed env var for app insights

### DIFF
--- a/infra/core/host/appservice.bicep
+++ b/infra/core/host/appservice.bicep
@@ -102,6 +102,7 @@ resource appService 'Microsoft.Web/sites@2022-03-01' = {
       {
         SCM_DO_BUILD_DURING_DEPLOYMENT: string(scmDoBuildDuringDeployment)
         ENABLE_ORYX_BUILD: string(enableOryxBuild)
+        ApplicationInsightsAgent_EXTENSION_VERSION: '~2'
       },
       runtimeName == 'python' ? { PYTHON_ENABLE_GUNICORN_MULTIWORKERS: 'true' } : {},
       !empty(applicationInsightsName) ? { APPLICATIONINSIGHTS_CONNECTION_STRING: applicationInsights.properties.ConnectionString } : {},

--- a/infra/core/host/appservice.bicep
+++ b/infra/core/host/appservice.bicep
@@ -102,7 +102,7 @@ resource appService 'Microsoft.Web/sites@2022-03-01' = {
       {
         SCM_DO_BUILD_DURING_DEPLOYMENT: string(scmDoBuildDuringDeployment)
         ENABLE_ORYX_BUILD: string(enableOryxBuild)
-        ApplicationInsightsAgent_EXTENSION_VERSION: '~2'
+        ApplicationInsightsAgent_EXTENSION_VERSION: contains(kind, 'linux') ? '~3' : '~2'
       },
       runtimeName == 'python' ? { PYTHON_ENABLE_GUNICORN_MULTIWORKERS: 'true' } : {},
       !empty(applicationInsightsName) ? { APPLICATIONINSIGHTS_CONNECTION_STRING: applicationInsights.properties.ConnectionString } : {},


### PR DESCRIPTION
## Purpose

Fixes #2023 
per documentation @ https://learn.microsoft.com/en-us/azure/azure-monitor/app/codeless-app-service?tabs=python#automate-monitoring

How it looks in Portal before deployed:
![Screenshot 2024-10-25 at 3 45 44 PM](https://github.com/user-attachments/assets/cf7754e2-baa8-4198-8a70-6a9862631f3b)

How it looks in Portal once deployed:
![Screenshot 2024-10-25 at 3 44 16 PM](https://github.com/user-attachments/assets/ed84f19f-6b68-4bb3-9cf6-f25a861dcfde)

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

N/A

