### PR TITLE
Switch to ACA by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ The repo includes sample data so it's ready to try end to end. In this sample ap
 Pricing varies per region and usage, so it isn't possible to predict exact costs for your usage.
 However, you can try the [Azure pricing calculator](https://azure.com/e/a87a169b256e43c089015fda8182ca87) for the resources below.
 
-- Azure App Service: Basic Tier with 1 CPU core, 1.75 GB RAM. Pricing per hour. [Pricing](https://azure.microsoft.com/pricing/details/app-service/linux/)
-- Azure Container Apps: Only provisioned if you deploy to Azure Container Apps following [the ACA deployment guide](docs/azure_container_apps.md). Consumption plan with 1 CPU core, 2.0 GB RAM. Pricing with Pay-as-You-Go. [Pricing](https://azure.microsoft.com/pricing/details/container-apps/)
+- Azure Container Apps: Default host for app deployment as of 10/28/2024. See more details in [the ACA deployment guide](docs/azure_container_apps.md). Consumption plan with 1 CPU core, 2.0 GB RAM. Pricing with Pay-as-You-Go. [Pricing](https://azure.microsoft.com/pricing/details/container-apps/)
+- Azure App Service: Only provisioned if you deploy to Azure App Service following [the App Service deployment guide](docs/azure_app_service.md).  Basic Tier with 1 CPU core, 1.75 GB RAM. Pricing per hour. [Pricing](https://azure.microsoft.com/pricing/details/app-service/linux/)
 - Azure OpenAI: Standard tier, GPT and Ada models. Pricing per 1K tokens used, and at least 1K tokens are used per question. [Pricing](https://azure.microsoft.com/pricing/details/cognitive-services/openai-service/)
 - Azure AI Document Intelligence: SO (Standard) tier using pre-built layout. Pricing per document page, sample documents have 261 pages total. [Pricing](https://azure.microsoft.com/pricing/details/form-recognizer/)
 - Azure AI Search: Basic tier, 1 replica, free level of semantic search. Pricing per hour. [Pricing](https://azure.microsoft.com/pricing/details/search/)
@@ -127,7 +127,7 @@ A related option is VS Code Dev Containers, which will open the project in your 
 
 ## Deploying
 
-The steps below will provision Azure resources and deploy the application code to Azure App Service. To deploy to Azure Container Apps instead, follow [the container apps deployment guide](docs/azure_container_apps.md).
+The steps below will provision Azure resources and deploy the application code to Azure Container Apps. To deploy to Azure App Service instead, follow [the app service deployment guide](docs/azure_app_service.md).
 
 1. Login to your Azure account:
 
@@ -136,6 +136,7 @@ The steps below will provision Azure resources and deploy the application code t
     ```
 
     For GitHub Codespaces users, if the previous command fails, try:
+
    ```shell
     azd auth login --use-device-code
     ```
@@ -157,7 +158,7 @@ It will look like the following:
 
 !['Output from running azd up'](docs/images/endpoint.png)
 
-> NOTE: It may take 5-10 minutes after you see 'SUCCESS' for the application to be fully deployed. If you see a "Python Developer" welcome screen or an error page, then wait a bit and refresh the page. See [guide on debugging App Service deployments](docs/appservice.md).
+> NOTE: It may take 5-10 minutes after you see 'SUCCESS' for the application to be fully deployed. If you see a "Python Developer" welcome screen or an error page, then wait a bit and refresh the page.
 
 ### Deploying again
 
@@ -261,7 +262,7 @@ Here are the most common failure scenarios and solutions:
 
 1. You see `CERTIFICATE_VERIFY_FAILED` when the `prepdocs.py` script runs. That's typically due to incorrect SSL certificates setup on your machine. Try the suggestions in this [StackOverflow answer](https://stackoverflow.com/questions/35569042/ssl-certificate-verify-failed-with-python3/43855394#43855394).
 
-1. After running `azd up` and visiting the website, you see a '404 Not Found' in the browser. Wait 10 minutes and try again, as it might be still starting up. Then try running `azd deploy` and wait again. If you still encounter errors with the deployed app, consult the [guide on debugging App Service deployments](docs/appservice.md). Please file an issue if the logs don't help you resolve the error.
+1. After running `azd up` and visiting the website, you see a '404 Not Found' in the browser. Wait 10 minutes and try again, as it might be still starting up. Then try running `azd deploy` and wait again. If you still encounter errors with the deployed app and are deploying to App Service, consult the [guide on debugging App Service deployments](docs/appservice.md). Please file an issue if the logs don't help you resolve the error.
 
 ### Resources
 

--- a/azure.yaml
+++ b/azure.yaml
@@ -8,10 +8,11 @@ services:
     project: ./app/backend
     language: py
     # Please check docs/azure_container_apps.md for more information on how to deploy to Azure Container Apps
-    # host: containerapp
-    # docker:
-    #  remoteBuild: true
-    host: appservice
+    host: containerapp
+    docker:
+      remoteBuild: true
+    # Please check docs/azure_app_service.md for more information on how to deploy to Azure App Service
+    # host: appservice
     hooks:
       # This hook is called when App Service is the host
       prepackage:

--- a/docs/azure_app_service.md
+++ b/docs/azure_app_service.md
@@ -1,0 +1,40 @@
+# Deploying on Azure App Service
+
+Due to [a limitation](https://github.com/Azure/azure-dev/issues/2736) of the Azure Developer CLI (`azd`), there can be only one host option in the [azure.yaml](../azure.yaml) file.
+By default, `host: containerapp` is used and `host: appservice` is commented out.
+
+To deploy to Azure Container Apps, please follow the following steps:
+
+1. Comment out `host: containerapp` and uncomment `host: appservice` in the [azure.yaml](../azure.yaml) file.
+
+2. Login to your Azure account:
+
+    ```bash
+    azd auth login
+    ```
+
+3. Create a new `azd` environment to store the deployment parameters:
+
+    ```bash
+    azd env new
+    ```
+
+    Enter a name that will be used for the resource group.
+    This will create a new folder in the `.azure` folder, and set it as the active environment for any calls to `azd` going forward.
+
+4. Set the deployment target to `appservice`:
+
+    ```bash
+    azd env set DEPLOYMENT_TARGET appservice
+    ```
+
+5. (Optional) This is the point where you can customize the deployment by setting other `azd` environment variables, in order to [use existing resources](docs/deploy_existing.md), [enable optional features (such as auth or vision)](docs/deploy_features.md), or [deploy to free tiers](docs/deploy_lowcost.md).
+6. Provision the resources and deploy the code:
+
+    ```bash
+    azd up
+    ```
+
+    This will provision Azure resources and deploy this sample to those resources, including building the search index based on the files found in the `./data` folder.
+
+    **Important**: Beware that the resources created by this command will incur immediate costs, primarily from the AI Search resource. These resources may accrue costs even if you interrupt the command before it is fully executed. You can run `azd down` or delete the resources manually to avoid unnecessary spending.

--- a/docs/azure_container_apps.md
+++ b/docs/azure_container_apps.md
@@ -1,7 +1,9 @@
 # Deploying on Azure Container Apps
 
 Due to [a limitation](https://github.com/Azure/azure-dev/issues/2736) of the Azure Developer CLI (`azd`), there can be only one host option in the [azure.yaml](../azure.yaml) file.
-By default, `host: appservice` is used and `host: containerapp` is commented out.
+By default, `host: containerapp` is used and `host: appservice` is commented out.
+
+However, if you have an older version of the repo, you may need to follow these steps to deploy to Container Apps instead, or you can stick with Azure App Service.
 
 To deploy to Azure Container Apps, please follow the following steps:
 
@@ -52,4 +54,4 @@ Please note dedicated workload profiles have a different billing model than Cons
 
 ## Private endpoints
 
-Private endpoints is still in private preview for Azure Conainer Apps and not supported for now.
+Private endpoints is still in private preview for Azure Container Apps and not supported for now.

--- a/docs/deploy_private.md
+++ b/docs/deploy_private.md
@@ -1,6 +1,8 @@
 
 # Deploying with private access
 
+⚠️ This feature is not yet compatible with Azure Container Apps, so you will need to [deploy to Azure App Service](./azure_app_service.md) instead.
+
 If you want to disable public access when deploying the Chat App, you can do so by setting `azd` environment values.
 
 ## Before you begin

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -261,7 +261,7 @@
       "value": "${TF_BUILD}"
     },
     "deploymentTarget": {
-      "value": "${DEPLOYMENT_TARGET=appservice}"
+      "value": "${DEPLOYMENT_TARGET=containerapps}"
     },
     "webAppExists": {
         "value": "${SERVICE_WEB_RESOURCE_EXISTS=false}"


### PR DESCRIPTION
## Purpose

Improve the developer experience for new developers by using ACA for faster deployment.
The biggest drawback of this change is that existing developers will need to keep a code change to azure.yaml in order to keep using App Service, since we can't do this with solely environment variables.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[X] Yes - existing devs need to follow app service guide to keep using it.
[ ] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No - I dont see an App Service mention
```

## Type of change

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.

