### PR TITLE
Fix regression from PR #2056: Allow whitespace in citation filenames

### DIFF
--- a/app/frontend/src/components/Answer/AnswerParser.tsx
+++ b/app/frontend/src/components/Answer/AnswerParser.tsx
@@ -8,7 +8,7 @@ type HtmlParsedAnswer = {
 
 // Function to validate citation format and check if dataPoint starts with possible citation
 function isCitationValid(contextDataPoints: any, citationCandidate: string): boolean {
-    const regex = /^[^\s]+\.[a-zA-Z0-9]+/;
+    const regex = /.+\.\w{1,}(?:#\S*)?$/;
     if (!regex.test(citationCandidate)) {
         return false;
     }
@@ -23,13 +23,11 @@ function isCitationValid(contextDataPoints: any, citationCandidate: string): boo
         return false;
     }
 
-    const isValidCitation = dataPointsArray.some(dataPoint => dataPoint.startsWith(citationCandidate));
+    const isValidCitation = dataPointsArray.some(dataPoint => {
+        return dataPoint.startsWith(citationCandidate);
+    });
 
-    if (!isValidCitation) {
-        return false;
-    }
-
-    return true;
+    return isValidCitation;
 }
 
 export function parseAnswerToHtml(answer: ChatAppResponse, isStreaming: boolean, onCitationClicked: (citationFilePath: string) => void): HtmlParsedAnswer {


### PR DESCRIPTION
## Purpose
This PR addresses a regression introduced in PR #2056 that caused issues with filenames containing whitespace. The regular expression used to validate citation filenames has been updated to allow internal whitespace, ensuring proper handling of such filenames.

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[x] No
```

## Type of change

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
