### PR TITLE
Upgrade Azure OpenAI API version and use AZURE_OPENAI_API_VERSION consistently

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -573,7 +573,8 @@ async def setup_clients():
         current_app.config[CONFIG_CREDENTIAL] = azure_credential
 
     if OPENAI_HOST.startswith("azure"):
-        api_version = os.getenv("AZURE_OPENAI_API_VERSION") or "2024-03-01-preview"
+        # https://learn.microsoft.com/azure/ai-services/openai/api-version-deprecation#latest-ga-api-release
+        api_version = os.getenv("AZURE_OPENAI_API_VERSION") or "2024-06-01"
         if OPENAI_HOST == "azure_custom":
             current_app.logger.info("OPENAI_HOST is azure_custom, setting up Azure OpenAI custom client")
             if not AZURE_OPENAI_CUSTOM_URL:

--- a/app/backend/prepdocs.py
+++ b/app/backend/prepdocs.py
@@ -115,6 +115,7 @@ def setup_embeddings_service(
     openai_custom_url: Union[str, None],
     openai_deployment: Union[str, None],
     openai_dimensions: int,
+    openai_api_version: str,
     openai_key: Union[str, None],
     openai_org: Union[str, None],
     disable_vectors: bool = False,
@@ -134,6 +135,7 @@ def setup_embeddings_service(
             open_ai_deployment=openai_deployment,
             open_ai_model_name=openai_model_name,
             open_ai_dimensions=openai_dimensions,
+            open_ai_api_version=openai_api_version,
             credential=azure_open_ai_credential,
             disable_batch=disable_batch_vectors,
         )
@@ -366,6 +368,8 @@ if __name__ == "__main__":
         openai_service=os.getenv("AZURE_OPENAI_SERVICE"),
         openai_custom_url=os.getenv("AZURE_OPENAI_CUSTOM_URL"),
         openai_deployment=os.getenv("AZURE_OPENAI_EMB_DEPLOYMENT"),
+        # https://learn.microsoft.com/azure/ai-services/openai/api-version-deprecation#latest-ga-api-release
+        openai_api_version=os.getenv("AZURE_OPENAI_API_VERSION") or "2024-06-01",
         openai_dimensions=openai_dimensions,
         openai_key=clean_key_if_exists(openai_key),
         openai_org=os.getenv("OPENAI_ORGANIZATION"),

--- a/app/backend/prepdocslib/embeddings.py
+++ b/app/backend/prepdocslib/embeddings.py
@@ -163,6 +163,7 @@ class AzureOpenAIEmbeddingService(OpenAIEmbeddings):
         open_ai_deployment: Union[str, None],
         open_ai_model_name: str,
         open_ai_dimensions: int,
+        open_ai_api_version: str,
         credential: Union[AsyncTokenCredential, AzureKeyCredential],
         open_ai_custom_url: Union[str, None] = None,
         disable_batch: bool = False,
@@ -176,6 +177,7 @@ class AzureOpenAIEmbeddingService(OpenAIEmbeddings):
         else:
             raise ValueError("Either open_ai_service or open_ai_custom_url must be provided")
         self.open_ai_deployment = open_ai_deployment
+        self.open_ai_api_version = open_ai_api_version
         self.credential = credential
 
     async def create_client(self) -> AsyncOpenAI:
@@ -196,7 +198,7 @@ class AzureOpenAIEmbeddingService(OpenAIEmbeddings):
         return AsyncAzureOpenAI(
             azure_endpoint=self.open_ai_endpoint,
             azure_deployment=self.open_ai_deployment,
-            api_version="2023-05-15",
+            api_version=self.open_ai_api_version,
             **auth_args,
         )
 

--- a/tests/test_prepdocs.py
+++ b/tests/test_prepdocs.py
@@ -62,6 +62,7 @@ async def test_compute_embedding_success(monkeypatch):
         open_ai_deployment="x",
         open_ai_model_name=MOCK_EMBEDDING_MODEL_NAME,
         open_ai_dimensions=MOCK_EMBEDDING_DIMENSIONS,
+        open_ai_api_version="test-api-version",
         credential=MockAzureCredential(),
         disable_batch=False,
     )
@@ -79,6 +80,7 @@ async def test_compute_embedding_success(monkeypatch):
         open_ai_deployment="x",
         open_ai_model_name=MOCK_EMBEDDING_MODEL_NAME,
         open_ai_dimensions=MOCK_EMBEDDING_DIMENSIONS,
+        open_ai_api_version="test-api-version",
         credential=MockAzureCredential(),
         disable_batch=True,
     )
@@ -149,6 +151,7 @@ async def test_compute_embedding_ratelimiterror_batch(monkeypatch, caplog):
                 open_ai_deployment="x",
                 open_ai_model_name=MOCK_EMBEDDING_MODEL_NAME,
                 open_ai_dimensions=MOCK_EMBEDDING_DIMENSIONS,
+                open_ai_api_version="test-api-version",
                 credential=MockAzureCredential(),
                 disable_batch=False,
             )
@@ -167,6 +170,7 @@ async def test_compute_embedding_ratelimiterror_single(monkeypatch, caplog):
                 open_ai_deployment="x",
                 open_ai_model_name=MOCK_EMBEDDING_MODEL_NAME,
                 open_ai_dimensions=MOCK_EMBEDDING_DIMENSIONS,
+                open_ai_api_version="test-api-version",
                 credential=MockAzureCredential(),
                 disable_batch=True,
             )
@@ -193,6 +197,7 @@ async def test_compute_embedding_autherror(monkeypatch, capsys):
             open_ai_deployment="x",
             open_ai_model_name=MOCK_EMBEDDING_MODEL_NAME,
             open_ai_dimensions=MOCK_EMBEDDING_DIMENSIONS,
+            open_ai_api_version="test-api-version",
             credential=MockAzureCredential(),
             disable_batch=False,
         )
@@ -205,6 +210,7 @@ async def test_compute_embedding_autherror(monkeypatch, capsys):
             open_ai_deployment="x",
             open_ai_model_name=MOCK_EMBEDDING_MODEL_NAME,
             open_ai_dimensions=MOCK_EMBEDDING_DIMENSIONS,
+            open_ai_api_version="test-api-version",
             credential=MockAzureCredential(),
             disable_batch=True,
         )

--- a/tests/test_searchmanager.py
+++ b/tests/test_searchmanager.py
@@ -275,6 +275,7 @@ async def test_update_content_with_embeddings(monkeypatch, search_info):
         open_ai_deployment="x",
         open_ai_model_name=MOCK_EMBEDDING_MODEL_NAME,
         open_ai_dimensions=MOCK_EMBEDDING_DIMENSIONS,
+        open_ai_api_version="test-api-version",
         credential=AzureKeyCredential("test"),
         disable_batch=True,
     )


### PR DESCRIPTION
## Purpose

Fixes #2090

This PR updates the API version to the latest GA release. We are not using any preview features, to the best of my knowledge, and I tested both function calling and gpt-vision functionality with the latest version.
This PR also makes sure we consistently use AZURE_OPENAI_API_VERSION when provided. We still have one slight bit of redundancy since prepdocs.py and app.py have their own setup. :=/

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
