### PR TITLE
let env var overrule .dot env setting

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,9 @@
             "env": {
                 "QUART_APP": "main:app",
                 "QUART_ENV": "development",
-                "QUART_DEBUG": "0"
+                "QUART_DEBUG": "0",
+                // Set this to "no-override" if you want env vars here to override AZD env vars
+                "LOADING_MODE_FOR_AZD_ENV_VARS": "override"
             },
             "args": [
                 "run",

--- a/app/backend/load_azd_env.py
+++ b/app/backend/load_azd_env.py
@@ -20,4 +20,4 @@ def load_azd_env():
     if not env_file_path:
         raise Exception("No default azd env file found")
     logger.info(f"Loading azd env from {env_file_path}")
-    load_dotenv(env_file_path, override=True)
+    load_dotenv(env_file_path, override=False)

--- a/app/backend/load_azd_env.py
+++ b/app/backend/load_azd_env.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import subprocess
 
 from dotenv import load_dotenv
@@ -19,5 +20,10 @@ def load_azd_env():
             env_file_path = entry["DotEnvPath"]
     if not env_file_path:
         raise Exception("No default azd env file found")
-    logger.info(f"Loading azd env from {env_file_path}")
-    load_dotenv(env_file_path, override=False)
+    loading_mode = os.getenv("LOADING_MODE_FOR_AZD_ENV_VARS") or "override"
+    if loading_mode == "no-override":
+        logger.info("Loading azd env from %s, but not overriding existing environment variables", env_file_path)
+        load_dotenv(env_file_path, override=False)
+    else:
+        logger.info("Loading azd env from %s, which may override existing environment variables", env_file_path)
+        load_dotenv(env_file_path, override=True)


### PR DESCRIPTION
 Overriding the env vars in then vscode launch.,json ""env": .." section does not work because of load_azd_env.py
always gives the dot env presence. Therefore i changed load_dotenv(env_file_path, override=True) to
load_dotenv(env_file_path, override=False) to let the env var win in favor to dot env file setting