### PR TITLE
fix: handle null speech URLs with fallback to empty string to resolve…

### DIFF
--- a/app/frontend/src/components/Answer/SpeechOutputAzure.tsx
+++ b/app/frontend/src/components/Answer/SpeechOutputAzure.tsx
@@ -44,7 +44,7 @@ export const SpeechOutputAzure = ({ answer, speechConfig, index, isStreaming }: 
             return;
         }
         if (speechConfig.speechUrls[index]) {
-            playAudio(speechConfig.speechUrls[index]);
+            playAudio(speechConfig.speechUrls[index] ?? "");
             return;
         }
         setIsLoading(true);


### PR DESCRIPTION
… TS error

## Purpose

This change resolves a TypeScript error where null speech URLs caused a type mismatch by using a fallback to an empty string. It ensures smooth operation when speech URLs are missing.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[x] No
```

## Type of change

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
