### PR TITLE
Update storage acct creation to include storageInfrastructureEncyption property

### DIFF
--- a/infra/core/storage/storage-account.bicep
+++ b/infra/core/storage/storage-account.bicep
@@ -38,7 +38,7 @@ var encryption = (storageInfrastructureEncryption == 'Enabled') ? {
   requireInfrastructureEncryption: false
 }
 
-resource storage 'Microsoft.Storage/storageAccounts@2022-05-01' = {
+resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   name: name
   location: location
   tags: tags

--- a/infra/core/storage/storage-account.bicep
+++ b/infra/core/storage/storage-account.bicep
@@ -25,11 +25,18 @@ param publicNetworkAccess string = 'Enabled'
 param sku object = { name: 'Standard_LRS' }
 @allowed([ 'None', 'AzureServices' ])
 param bypass string = 'AzureServices'
+param storageInfrastructureEncryption string = 'Disabled'
 
 var networkAcls = (publicNetworkAccess == 'Enabled') ? {
   bypass: bypass
   defaultAction: 'Allow'
 } : { defaultAction: 'Deny' }
+
+var encryption = (storageInfrastructureEncryption == 'Enabled') ? {
+  requireInfrastructureEncryption: true
+} : {
+  requireInfrastructureEncryption: false
+}
 
 resource storage 'Microsoft.Storage/storageAccounts@2022-05-01' = {
   name: name
@@ -49,6 +56,7 @@ resource storage 'Microsoft.Storage/storageAccounts@2022-05-01' = {
     networkAcls: networkAcls
     publicNetworkAccess: publicNetworkAccess
     supportsHttpsTrafficOnly: supportsHttpsTrafficOnly
+    encryption: encryption
   }
 
   resource blobServices 'blobServices' = if (!empty(containers)) {

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -36,6 +36,7 @@ param storageResourceGroupName string = '' // Set in main.parameters.json
 param storageResourceGroupLocation string = location
 param storageContainerName string = 'content'
 param storageSkuName string // Set in main.parameters.json
+param storageInfrastructureEncryption string // Set in main.parameters.json
 
 param userStorageAccountName string = ''
 param userStorageContainerName string = 'user-content'
@@ -662,6 +663,7 @@ module storage 'core/storage/storage-account.bicep' = {
         publicAccess: 'None'
       }
     ]
+    storageInfrastructureEncryption: storageInfrastructureEncryption
   }
 }
 
@@ -688,6 +690,7 @@ module userStorage 'core/storage/storage-account.bicep' = if (useUserUpload) {
         publicAccess: 'None'
       }
     ]
+    storageInfrastructureEncryption: storageInfrastructureEncryption
   }
 }
 

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -80,6 +80,9 @@
     "storageSkuName": {
       "value": "${AZURE_STORAGE_SKU=Standard_LRS}"
     },
+    "storageInfrastructureEncryption": {
+      "value": "${AZURE_STORAGE_INFRA_ENCRYPTION}"
+    },
     "appServicePlanName": {
       "value": "${AZURE_APP_SERVICE_PLAN}"
     },


### PR DESCRIPTION
## Purpose

Update storage acct creation to include storageInfrastructureEncyption property

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
