### PR TITLE
[Bugfix] The "send" button for chat should be enabled for logged in users

### DIFF
--- a/app/frontend/src/components/QuestionInput/QuestionInput.tsx
+++ b/app/frontend/src/components/QuestionInput/QuestionInput.tsx
@@ -65,7 +65,7 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, init
     };
 
     const disableRequiredAccessControl = requireLogin && !loggedIn;
-    const sendQuestionDisabled = disabled || !question.trim();
+    const sendQuestionDisabled = disabled || !question.trim() || disableRequiredAccessControl;
 
     if (disableRequiredAccessControl) {
         placeholder = "Please login to continue...";

--- a/app/frontend/src/components/QuestionInput/QuestionInput.tsx
+++ b/app/frontend/src/components/QuestionInput/QuestionInput.tsx
@@ -65,7 +65,7 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, init
     };
 
     const disableRequiredAccessControl = requireLogin && !loggedIn;
-    const sendQuestionDisabled = disabled || !question.trim() || requireLogin;
+    const sendQuestionDisabled = disabled || !question.trim();
 
     if (disableRequiredAccessControl) {
         placeholder = "Please login to continue...";


### PR DESCRIPTION
## Purpose

Currently, the send button is disabled when login is required, even if the user is already logged in (see #2071). While chatting can still be done via the Enter key, the disabled button is redundant since the text input box is already blocked when the user is not logged in. This unnecessary check has been removed to address this bug.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[ X ] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[ X ] No
```

## Type of change

```
[ X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
