### PR TITLE
Export `VITE_` environment variables in `Start.sh`

### DIFF
--- a/app/start.sh
+++ b/app/start.sh
@@ -1,8 +1,25 @@
 #!/bin/sh
 
-# cd into the parent directory of the script, 
+# cd into the parent directory of the script,
 # so that the script generates virtual environments always in the same path.
 cd "${0%/*}" || exit 1
+
+echo ""
+echo "Loading azd .env file from current environment"
+echo ""
+
+while IFS='=' read -r key value; do
+    value=$(echo "$value" | sed 's/^"//' | sed 's/"$//')
+    # Only export variables that start with "VITE_"
+    case "$key" in
+        VITE_*)
+            export "$key=$value"
+            echo "Exported $key"
+            ;;
+    esac
+done <<EOF
+$(azd env get-values)
+EOF
 
 cd ../
 echo 'Creating python virtual environment ".venv"'


### PR DESCRIPTION
## Purpose
This PR implements the change discussed in issue https://github.com/Azure-Samples/azure-search-openai-demo/issues/2227

This change partially reverts commit https://github.com/Azure-Samples/azure-search-openai-demo/pull/1986/commits/59e01c8da75ef8b9414915a85f2d2b572f41e413 - it restores exporting of environment variables from `azd env` at the beginning of `start.sh` script. However, only variables that begin with `VITE_` are being exported - they might be used by the frontend when the application is started locally.


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.

The `start.sh` script is not covered by tests.