### PR TITLE
Revert upgrade of msgraph-core SDK

### DIFF
--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -197,7 +197,7 @@ msal==1.30.0
     #   msal-extensions
 msal-extensions==1.2.0
     # via azure-identity
-msgraph-core==1.1.8
+msgraph-core==1.1.7
     # via msgraph-sdk
 msgraph-sdk==1.16.0
     # via -r requirements.in

--- a/docs/azd.md
+++ b/docs/azd.md
@@ -17,7 +17,7 @@ The `azd up` command uses the `azure.yaml` file combined with the infrastructure
 
 Next, it provisions the resources based on `main.bicep` and `main.parameters.json`. At that point, since there is no default value for the OpenAI resource location, it asks you to pick a location from a short list of available regions. Then it will send requests to Azure to provision all the required resources. With everything provisioned, it runs the `postprovision` hook to process the local data and add it to an Azure AI Search index.
 
-Finally, it looks at `azure.yaml` to determine the Azure host (appservice, in this case) and uploads the zip to Azure App Service. The `azd up` command is now complete, but it may take another 5-10 minutes for the App Service app to be fully available and working, especially for the initial deploy.
+Finally, it looks at `azure.yaml` to determine the Azure host and uploads the zip to Azure App Service. The `azd up` command is now complete, but it may take another 5-10 minutes for the App Service app to be fully available and working, especially for the initial deploy.
 
 Related commands are `azd provision` for just provisioning (if infra files change) and `azd deploy` for just deploying updated app code.
 


### PR DESCRIPTION
## Purpose

This issue broke the auth setup:
https://github.com/microsoftgraph/msgraph-sdk-python-core/issues/781

We need tests that run the auth scripts! The CI didn't find the issue, but a mocked test would have.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [X] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works :( - we need auth tests
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
