### PR TITLE
Handle lack of support for docx/pptx/xlsx for media description

### DIFF
--- a/app/backend/prepdocslib/pdfparser.py
+++ b/app/backend/prepdocslib/pdfparser.py
@@ -14,6 +14,7 @@ from azure.ai.documentintelligence.models import (
 )
 from azure.core.credentials import AzureKeyCredential
 from azure.core.credentials_async import AsyncTokenCredential
+from azure.core.exceptions import HttpResponseError
 from PIL import Image
 from pypdf import PdfReader
 
@@ -68,6 +69,7 @@ class DocumentAnalysisParser(Parser):
         async with DocumentIntelligenceClient(
             endpoint=self.endpoint, credential=self.credential
         ) as document_intelligence_client:
+            file_analyzed = False
             if self.use_content_understanding:
                 if self.content_understanding_endpoint is None:
                     raise ValueError("Content Understanding is enabled but no endpoint was provided")
@@ -77,15 +79,29 @@ class DocumentAnalysisParser(Parser):
                     )
                 cu_describer = ContentUnderstandingDescriber(self.content_understanding_endpoint, self.credential)
                 content_bytes = content.read()
-                poller = await document_intelligence_client.begin_analyze_document(
-                    model_id="prebuilt-layout",
-                    analyze_request=AnalyzeDocumentRequest(bytes_source=content_bytes),
-                    output=["figures"],
-                    features=["ocrHighResolution"],
-                    output_content_format="markdown",
-                )
-                doc_for_pymupdf = pymupdf.open(stream=io.BytesIO(content_bytes))
-            else:
+                try:
+                    poller = await document_intelligence_client.begin_analyze_document(
+                        model_id="prebuilt-layout",
+                        analyze_request=AnalyzeDocumentRequest(bytes_source=content_bytes),
+                        output=["figures"],
+                        features=["ocrHighResolution"],
+                        output_content_format="markdown",
+                    )
+                    doc_for_pymupdf = pymupdf.open(stream=io.BytesIO(content_bytes))
+                    file_analyzed = True
+                except HttpResponseError as e:
+                    content.seek(0)
+                    if e.error.code == "InvalidArgument":
+                        logger.warning(
+                            "This document type does not support media description. Proceeding with standard analysis."
+                        )
+                    else:
+                        logger.warning(
+                            "Unexpected error analyzing document for media description: %s. Proceeding with standard analysis.",
+                            e,
+                        )
+
+            if file_analyzed is False:
                 poller = await document_intelligence_client.begin_analyze_document(
                     model_id=self.model_id, analyze_request=content, content_type="application/octet-stream"
                 )

--- a/app/backend/prepdocslib/pdfparser.py
+++ b/app/backend/prepdocslib/pdfparser.py
@@ -91,7 +91,7 @@ class DocumentAnalysisParser(Parser):
                     file_analyzed = True
                 except HttpResponseError as e:
                     content.seek(0)
-                    if e.error.code == "InvalidArgument":
+                    if e.error and e.error.code == "InvalidArgument":
                         logger.warning(
                             "This document type does not support media description. Proceeding with standard analysis."
                         )

--- a/app/backend/prepdocslib/pdfparser.py
+++ b/app/backend/prepdocslib/pdfparser.py
@@ -92,11 +92,11 @@ class DocumentAnalysisParser(Parser):
                 except HttpResponseError as e:
                     content.seek(0)
                     if e.error and e.error.code == "InvalidArgument":
-                        logger.warning(
+                        logger.error(
                             "This document type does not support media description. Proceeding with standard analysis."
                         )
                     else:
-                        logger.warning(
+                        logger.error(
                             "Unexpected error analyzing document for media description: %s. Proceeding with standard analysis.",
                             e,
                         )

--- a/docs/deploy_features.md
+++ b/docs/deploy_features.md
@@ -163,7 +163,6 @@ By default, if your documents contain image-like figures, the data ingestion pro
 so users will not be able to ask questions about them.
 
 You can optionably enable the description of media content using Azure Content Understanding. When enabled, the data ingestion process will send figures to Azure Content Understanding and replace the figure with the description in the indexed document.
-To learn more about this process and compare it to the gpt-4 vision integration, see [this guide](./data_ingestion.md#media-description).
 
 To enable media description with Azure Content Understanding, run:
 
@@ -174,6 +173,9 @@ azd env set USE_MEDIA_DESCRIBER_AZURE_CU true
 If you have already run `azd up`, you will need to run `azd provision` to create the new Content Understanding service.
 If you have already indexed your documents and want to re-index them with the media descriptions,
 first [remove the existing documents](./data_ingestion.md#removing-documents) and then [re-ingest the data](./data_ingestion.md#indexing-additional-documents).
+
+⚠️ This feature does not yet support DOCX, PPTX, or XLSX formats. If you have figures in those formats, they will be ignored.
+Convert them first to PDF or image formats to enable media description.
 
 ## Enabling client-side chat history
 

--- a/tests/test_pdfparser.py
+++ b/tests/test_pdfparser.py
@@ -336,7 +336,7 @@ async def test_parse_unsupportedformat(monkeypatch, caplog):
                 }
             }
             response = Mock(status_code=500, headers={})
-            response.text = lambda encoding=None: json.dumps(json.dumps(message).encode("utf-8"))
+            response.text = lambda encoding=None: json.dumps(message).encode("utf-8")
             response.headers["content-type"] = "application/json"
             response.content_type = "application/json"
             raise FakeHttpResponse(response, FakeErrorOne())

--- a/tests/test_pdfparser.py
+++ b/tests/test_pdfparser.py
@@ -362,7 +362,7 @@ async def test_parse_unsupportedformat(monkeypatch, caplog):
     )
     content = io.BytesIO(b"pdf content bytes")
     content.name = "test.docx"
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.ERROR):
         pages = [page async for page in parser.parse(content)]
         assert "This document type does not support media description." in caplog.text
 


### PR DESCRIPTION
## Purpose

Fixes #2242 

Unfortunately, the figures extraction doesn't yet work for office documents. This PR makes the flow default to standard ingestion for them. We could also have it error out entirely, like it does now, but with a more helpful message. Am not sure what developers would prefer.

Still working on the unit test

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
