### PR TITLE
WIP: Feature/Add Langfuse Integration for User Feedback Tracking

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -26,14 +26,18 @@ from azure.search.documents.aio import SearchClient
 from azure.search.documents.indexes.aio import SearchIndexClient
 from azure.storage.blob.aio import ContainerClient
 from azure.storage.blob.aio import StorageStreamDownloader as BlobDownloader
-from azure.storage.filedatalake.aio import FileSystemClient
-from azure.storage.filedatalake.aio import StorageStreamDownloader as DatalakeDownloader
+from azure.storage.filedatalake.aio import (
+    FileSystemClient,
+)
+from azure.storage.filedatalake.aio import (
+    StorageStreamDownloader as DatalakeDownloader,
+)
+from langfuse import Langfuse
+from langfuse.decorators import observe
 from openai import AsyncAzureOpenAI, AsyncOpenAI
 from opentelemetry.instrumentation.aiohttp_client import AioHttpClientInstrumentor
 from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
-from opentelemetry.instrumentation.httpx import (
-    HTTPXClientInstrumentor,
-)
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from opentelemetry.instrumentation.openai import OpenAIInstrumentor
 from quart import (
     Blueprint,
@@ -93,6 +97,13 @@ from prepdocs import (
 )
 from prepdocslib.filestrategy import UploadUserFileStrategy
 from prepdocslib.listfilestrategy import File
+
+# Initialize Langfuse client
+langfuse = Langfuse(
+    secret_key=os.getenv("LANGFUSE_SECRET_KEY"),
+    public_key=os.getenv("LANGFUSE_PUBLIC_KEY"),
+    host=os.getenv("LANGFUSE_HOST", "https://cloud.langfuse.com"),
+)
 
 bp = Blueprint("routes", __name__, static_folder="static")
 # Fix Windows registry issue with mimetypes
@@ -169,13 +180,26 @@ async def content_file(path: str, auth_claims: Dict[str, Any]):
 
 @bp.route("/ask", methods=["POST"])
 @authenticated
+@observe()
 async def ask(auth_claims: Dict[str, Any]):
     if not request.is_json:
         return jsonify({"error": "request must be json"}), 415
+
     request_json = await request.get_json()
     context = request_json.get("context", {})
     context["auth_claims"] = auth_claims
+
     try:
+        # Create a trace for this ask request
+        trace = langfuse.trace(
+            metadata={"endpoint": "/ask", "method": "POST", "entra_oid": auth_claims.get("oid", "anonymous")}
+        )
+
+        # Create a generation
+        generation = trace.generation(
+            name="ask_response", metadata={"messages": request_json.get("messages", []), "context": context}
+        )
+
         use_gpt4v = context.get("overrides", {}).get("use_gpt4v", False)
         approach: Approach
         if use_gpt4v and CONFIG_ASK_VISION_APPROACH in current_app.config:
@@ -185,8 +209,14 @@ async def ask(auth_claims: Dict[str, Any]):
         r = await approach.run(
             request_json["messages"], context=context, session_state=request_json.get("session_state")
         )
+
+        # End the generation after getting response
+        generation.end(metadata={"model": approach.__class__.__name__, "use_gpt4v": use_gpt4v})
+
         return jsonify(r)
     except Exception as error:
+        if "generation" in locals():
+            generation.end(error=str(error))
         return error_response(error, "/ask")
 
 
@@ -208,6 +238,7 @@ async def format_as_ndjson(r: AsyncGenerator[dict, None]) -> AsyncGenerator[str,
 
 @bp.route("/chat", methods=["POST"])
 @authenticated
+@observe()
 async def chat(auth_claims: Dict[str, Any]):
     if not request.is_json:
         return jsonify({"error": "request must be json"}), 415
@@ -242,39 +273,80 @@ async def chat(auth_claims: Dict[str, Any]):
 
 @bp.route("/chat/stream", methods=["POST"])
 @authenticated
+@observe()
 async def chat_stream(auth_claims: Dict[str, Any]):
     if not request.is_json:
         return jsonify({"error": "request must be json"}), 415
+
     request_json = await request.get_json()
     context = request_json.get("context", {})
     context["auth_claims"] = auth_claims
-    try:
-        use_gpt4v = context.get("overrides", {}).get("use_gpt4v", False)
-        approach: Approach
-        if use_gpt4v and CONFIG_CHAT_VISION_APPROACH in current_app.config:
-            approach = cast(Approach, current_app.config[CONFIG_CHAT_VISION_APPROACH])
-        else:
-            approach = cast(Approach, current_app.config[CONFIG_CHAT_APPROACH])
 
-        # If session state is provided, persists the session state,
-        # else creates a new session_id depending on the chat history options enabled.
-        session_state = request_json.get("session_state")
-        if session_state is None:
-            session_state = create_session_id(
-                current_app.config[CONFIG_CHAT_HISTORY_COSMOS_ENABLED],
-                current_app.config[CONFIG_CHAT_HISTORY_BROWSER_ENABLED],
-            )
-        result = await approach.run_stream(
-            request_json["messages"],
-            context=context,
-            session_state=session_state,
+    try:
+        # Create trace_id at the start
+        trace_id = create_session_id(True, True)
+
+        # Make trace_id available at all levels
+        context["trace_id"] = trace_id
+        if "overrides" not in context:
+            context["overrides"] = {}
+        context["overrides"]["trace_id"] = trace_id
+
+        current_app.logger.info(f"Generated trace_id: {trace_id}")
+
+        # Create a new trace with unique ID and generation at the start
+        trace = langfuse.trace(
+            id=trace_id,
+            metadata={"endpoint": "/chat/stream", "method": "POST", "entra_oid": auth_claims.get("oid", "anonymous")},
         )
-        response = await make_response(format_as_ndjson(result))
-        response.timeout = None  # type: ignore
-        response.mimetype = "application/json-lines"
-        return response
+
+        # Create generation early
+        generation = trace.generation(
+            name="chat_stream_response", metadata={"messages": request_json.get("messages", []), "context": context}
+        )
+
+        current_app.logger.info(f"Generated trace_id: {trace_id}")
+
+        try:
+            use_gpt4v = context.get("overrides", {}).get("use_gpt4v", False)
+            approach: Approach
+            if use_gpt4v and CONFIG_CHAT_VISION_APPROACH in current_app.config:
+                approach = cast(Approach, current_app.config[CONFIG_CHAT_VISION_APPROACH])
+            else:
+                approach = cast(Approach, current_app.config[CONFIG_CHAT_APPROACH])
+
+            session_state = request_json.get("session_state")
+            if session_state is None:
+                session_state = create_session_id(
+                    current_app.config[CONFIG_CHAT_HISTORY_COSMOS_ENABLED],
+                    current_app.config[CONFIG_CHAT_HISTORY_BROWSER_ENABLED],
+                )
+
+            # Get result first
+            result = await approach.run_stream(
+                request_json["messages"],
+                context=context,
+                session_state=session_state,
+            )
+
+            # Create response after getting result
+            response = await make_response(format_as_ndjson(result))
+            response.timeout = None  # type: ignore
+            response.mimetype = "application/json-lines"
+
+            # End generation before returning response
+            generation.end(metadata={"model": approach.__class__.__name__, "use_gpt4v": use_gpt4v, "status": "success"})
+
+            return response
+
+        except Exception as inner_error:
+            current_app.logger.error(f"Error in chat processing: {inner_error}")
+            generation.end(error=str(inner_error), metadata={"status": "error"})
+            raise inner_error
+
     except Exception as error:
-        return error_response(error, "/chat")
+        current_app.logger.error(f"Error in chat_stream: {error}")
+        return error_response(error, "/chat/stream")
 
 
 # Send MSAL.js settings to the client UI
@@ -404,6 +476,43 @@ async def list_uploaded(auth_claims: dict[str, Any]):
         if error.status_code != 404:
             current_app.logger.exception("Error listing uploaded files", error)
     return jsonify(files), 200
+
+
+@bp.route("/feedback", methods=["POST"])
+@authenticated
+async def feedback(auth_claims: Dict[str, Any]):
+    if not request.is_json:
+        return jsonify({"error": "request must be json"}), 415
+
+    try:
+        request_json = await request.get_json()
+        trace_id = request_json.get("trace_id")
+        value = request_json.get("value")
+
+        current_app.logger.info(f"Received feedback request: {request_json}")
+
+        if not trace_id or value is None:
+            return jsonify({"error": "trace_id and value are required"}), 400
+
+        # Add LLM provider info to the feedback
+        llm_provider = os.getenv("OPENAI_HOST", "openai")
+        score = langfuse.score(
+            trace_id=trace_id,
+            name="user_feedback_thumbs",
+            value=value,
+            comment=None,
+            metadata={
+                "llm_provider": llm_provider,
+                "model": os.getenv("AZURE_OPENAI_CHATGPT_MODEL", "gpt-4") if llm_provider == "azure" else "gpt-4",
+            },
+        )
+
+        current_app.logger.info(f"Successfully submitted feedback: {score}")
+
+        return jsonify({"message": "Feedback received successfully", "trace_id": trace_id, "value": value}), 200
+    except Exception as error:
+        current_app.logger.error(f"Error in feedback endpoint: {error}")
+        return jsonify({"error": str(error)}), 500
 
 
 @bp.before_app_serving

--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -193,6 +193,11 @@ class ChatReadRetrieveReadApproach(ChatApproach):
 
         data_points = {"text": sources_content}
 
+        # Get trace_id from all possible locations
+        trace_id = (
+            overrides.get("trace_id") or overrides.get("context", {}).get("trace_id") or auth_claims.get("trace_id")
+        )
+
         extra_info = {
             "data_points": data_points,
             "thoughts": [
@@ -231,7 +236,14 @@ class ChatReadRetrieveReadApproach(ChatApproach):
                     ),
                 ),
             ],
+            "trace_id": trace_id,  # Add trace_id
         }
+
+        # Log for verification
+        print(f"trace_id in extra_info: {extra_info['trace_id']}")
+
+        # Log for debugging
+        print(f"extra_info in run_until_final_call: {extra_info}")
 
         chat_coroutine = self.openai_client.chat.completions.create(
             # Azure OpenAI takes the deployment name as the model name

--- a/app/frontend/src/api/models.ts
+++ b/app/frontend/src/api/models.ts
@@ -1,3 +1,5 @@
+import { FeedbackProviderOptions } from "../components/HistoryProviders/IProvider";
+
 export const enum RetrievalMode {
     Hybrid = "hybrid",
     Vectors = "vectors",
@@ -54,6 +56,7 @@ export type ResponseContext = {
     data_points: string[];
     followup_questions: string[] | null;
     thoughts: Thoughts[];
+    trace_id: string; // Make this required
 };
 
 export type ChatAppResponseOrError = {
@@ -67,7 +70,13 @@ export type ChatAppResponseOrError = {
 export type ChatAppResponse = {
     message: ResponseMessage;
     delta: ResponseMessage;
-    context: ResponseContext;
+    context: {
+        data_points: string[];
+        followup_questions: string[] | null;
+        thoughts: Thoughts[];
+        trace_id?: string;
+        feedback?: number;
+    };
     session_state: any;
 };
 
@@ -122,4 +131,21 @@ export type HistroyApiResponse = {
     title: string;
     answers: any;
     timestamp: number;
+};
+
+export interface AppConfig {
+    showUserFeedback: boolean;
+    feedbackProvider: FeedbackProviderOptions;
+}
+
+export interface FeedbackRequest {
+    trace_id: string;
+    value: number;
+    type: "thumbs";
+}
+
+export type FeedbackResponse = {
+    trace_id: string;
+    status: "success" | "error";
+    message?: string;
 };

--- a/app/frontend/src/components/Answer/Answer.module.css
+++ b/app/frontend/src/components/Answer/Answer.module.css
@@ -119,6 +119,53 @@ sup {
     width: fit-content;
 }
 
+.feedbackMessage {
+    position: fixed;
+    bottom: 1.25rem;
+    right: 1.25rem;
+    padding: 0.625rem 1.25rem;
+    background-color: #4caf50;
+    color: white;
+    border-radius: 0.25rem;
+    z-index: 1000;
+    animation: fadeInOut 3s ease;
+}
+
+.feedbackButtonClicked i {
+    color: #323130 !important; /* Darker color for solid icons */
+}
+
+.feedbackButton:hover i {
+    color: #201f1e !important; /* Darker on hover */
+}
+
+.errorMessage {
+    position: fixed;
+    bottom: 1.25rem;
+    right: 1.25rem;
+    padding: 0.625rem 1.25rem;
+    background-color: #f44336;
+    color: white;
+    border-radius: 0.25rem;
+    z-index: 1000;
+    animation: fadeInOut 3s ease;
+}
+
+@keyframes fadeInOut {
+    0% {
+        opacity: 0;
+    }
+    10% {
+        opacity: 1;
+    }
+    90% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+    }
+}
+
 @keyframes loading {
     0% {
         content: "";

--- a/app/frontend/src/components/Answer/Answer.tsx
+++ b/app/frontend/src/components/Answer/Answer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect, useRef, useContext } from "react";
 import { Stack, IconButton } from "@fluentui/react";
 import { useTranslation } from "react-i18next";
 import DOMPurify from "dompurify";
@@ -7,11 +7,17 @@ import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 
 import styles from "./Answer.module.css";
-import { ChatAppResponse, getCitationFilePath, SpeechConfig } from "../../api";
+import { type ChatAppResponse, getCitationFilePath, type SpeechConfig } from "../../api";
 import { parseAnswerToHtml } from "./AnswerParser";
 import { AnswerIcon } from "./AnswerIcon";
 import { SpeechOutputBrowser } from "./SpeechOutputBrowser";
 import { SpeechOutputAzure } from "./SpeechOutputAzure";
+import { useFeedback } from "./FeedbackContext";
+import { useHistoryManager } from "../HistoryProviders/HistoryManager";
+import { HistoryProviderOptions } from "../HistoryProviders/IProvider";
+import { FeedbackStore } from "./FeedbackStore";
+import { useLogin } from "../../authConfig";
+import { LoginContext } from "../../loginContext";
 
 interface Props {
     answer: ChatAppResponse;
@@ -19,6 +25,7 @@ interface Props {
     speechConfig: SpeechConfig;
     isSelected?: boolean;
     isStreaming: boolean;
+    historyFeedback?: number;
     onCitationClicked: (filePath: string) => void;
     onThoughtProcessClicked: () => void;
     onSupportingContentClicked: () => void;
@@ -28,28 +35,97 @@ interface Props {
     showSpeechOutputAzure?: boolean;
 }
 
-export const Answer = ({
-    answer,
-    index,
-    speechConfig,
-    isSelected,
-    isStreaming,
-    onCitationClicked,
-    onThoughtProcessClicked,
-    onSupportingContentClicked,
-    onFollowupQuestionClicked,
-    showFollowupQuestions,
-    showSpeechOutputAzure,
-    showSpeechOutputBrowser
-}: Props) => {
+interface FeedbackData {
+    store: FeedbackStore;
+    traceId: string | undefined;
+    historyValue: number | undefined;
+}
+
+// Add this new hook to manage feedback state properly
+const useFeedbackState = (traceId: string | undefined, historyFeedback: number | undefined) => {
+    const [feedbackValue, setFeedbackValue] = useState<number | null>(null);
+    const initializeAttempted = useRef(false);
+    const feedbackStore = useMemo(() => FeedbackStore.getInstance(), []);
+
+    // Reset state when traceId changes
+    useEffect(() => {
+        setFeedbackValue(null);
+        initializeAttempted.current = false;
+    }, [traceId]);
+
+    // Load feedback data
+    useEffect(() => {
+        const loadFeedback = async () => {
+            if (!traceId || initializeAttempted.current) return;
+
+            try {
+                initializeAttempted.current = true;
+                console.log(`Initializing feedback for trace ${traceId}`);
+
+                // First try to get cached feedback
+                const cachedValue = await feedbackStore.getFeedback(traceId);
+                if (cachedValue !== null) {
+                    console.log(`Found cached feedback for ${traceId}:`, cachedValue);
+                    setFeedbackValue(cachedValue);
+                    return;
+                }
+
+                // Then try history feedback
+                if (historyFeedback !== undefined) {
+                    console.log(`Using history feedback for ${traceId}:`, historyFeedback);
+                    setFeedbackValue(historyFeedback);
+                    await feedbackStore.setFeedback(traceId, historyFeedback);
+                }
+            } catch (error) {
+                console.error(`Failed to load feedback for ${traceId}:`, error);
+                initializeAttempted.current = false;
+            }
+        };
+
+        loadFeedback();
+    }, [traceId, historyFeedback, feedbackStore]);
+
+    return { feedbackValue, setFeedbackValue, feedbackStore };
+};
+
+export const Answer = ({ answer, historyFeedback, ...props }: Props) => {
     const followupQuestions = answer.context?.followup_questions;
-    const parsedAnswer = useMemo(() => parseAnswerToHtml(answer, isStreaming, onCitationClicked), [answer]);
+    const parsedAnswer = useMemo(
+        () => parseAnswerToHtml(answer, props.isStreaming, props.onCitationClicked),
+        [answer, props.isStreaming, props.onCitationClicked]
+    );
     const { t } = useTranslation();
     const sanitizedAnswerHtml = DOMPurify.sanitize(parsedAnswer.answerHtml);
     const [copied, setCopied] = useState(false);
+    const { feedbackState } = useFeedback();
+    const historyManager = useHistoryManager(HistoryProviderOptions.IndexedDB);
+    const traceId = answer.context?.trace_id;
+    const { loggedIn } = useContext(LoginContext);
+    const useAuth = useLogin && loggedIn;
+
+    const answerContextValue = useMemo(
+        () => ({
+            fullContext: answer.context,
+            traceId: answer.context?.trace_id,
+            fullAnswer: answer,
+            hasTrace: Boolean(answer.context?.trace_id),
+            contextKeys: Object.keys(answer.context || {})
+        }),
+        [answer]
+    );
+
+    const feedback = useMemo<FeedbackData>(
+        () => ({
+            store: FeedbackStore.getInstance(),
+            traceId: answer.context?.trace_id,
+            historyValue: historyFeedback
+        }),
+        [answer.context?.trace_id, historyFeedback]
+    );
+
+    const { feedbackValue, setFeedbackValue, feedbackStore } = useFeedbackState(answer.context?.trace_id, historyFeedback);
 
     const handleCopy = () => {
-        // Single replace to remove all HTML tags to remove the citations
         const textToCopy = sanitizedAnswerHtml.replace(/<a [^>]*><sup>\d+<\/sup><\/a>|<[^>]+>/g, "");
 
         navigator.clipboard
@@ -61,12 +137,100 @@ export const Answer = ({
             .catch(err => console.error("Failed to copy text: ", err));
     };
 
+    const handleFeedback = async (value: number) => {
+        if (!feedback.traceId) return;
+
+        try {
+            setFeedbackValue(value);
+
+            await feedbackStore.setFeedback(feedback.traceId, value);
+
+            if (useAuth) {
+                await Promise.all([
+                    historyManager.updateFeedback(feedback.traceId, value),
+                    fetch("/feedback", {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({
+                            trace_id: feedback.traceId,
+                            value,
+                            type: "thumbs"
+                        })
+                    }).then(res => {
+                        if (!res.ok) throw new Error("Failed to submit feedback to server");
+                    })
+                ]);
+            }
+
+            const storedValue = await feedbackStore.getFeedback(feedback.traceId);
+            if (storedValue !== value) {
+                console.warn(`Local feedback verification failed: stored=${storedValue}, expected=${value}`);
+            }
+
+            // Show success message
+            const feedbackMessage = document.createElement("div");
+            feedbackMessage.className = styles.feedbackMessage;
+            feedbackMessage.textContent = value ? "Thanks for the positive feedback!" : "Thanks for the feedback. We'll work to improve.";
+            document.body.appendChild(feedbackMessage);
+            setTimeout(() => feedbackMessage.remove(), 3000);
+        } catch (error) {
+            console.error(`Failed to store feedback for ${feedback.traceId}:`, error);
+            // Show error in UI
+            const errorMessage = document.createElement("div");
+            errorMessage.className = styles.errorMessage;
+            errorMessage.textContent = error instanceof Error ? error.message : "Failed to submit feedback";
+            document.body.appendChild(errorMessage);
+            setTimeout(() => errorMessage.remove(), 3000);
+        }
+    };
+
+    useEffect(() => {
+        const isDevelopment = import.meta.env?.DEV ?? false;
+        if (isDevelopment) {
+            console.log("Answer mounted with context:", answerContextValue);
+        }
+    }, [answerContextValue]);
+
+    const renderFeedbackButton = () => {
+        if (feedbackValue !== null) {
+            return (
+                <IconButton
+                    style={{ color: "black" }}
+                    className={styles.feedbackButtonClicked}
+                    iconProps={{ iconName: feedbackValue === 1 ? "LikeSolid" : "DislikeSolid" }}
+                    title={feedbackValue === 1 ? t("Good response") : t("Bad response")}
+                    disabled={true}
+                />
+            );
+        }
+
+        return (
+            <>
+                <IconButton
+                    style={{ color: "black" }}
+                    iconProps={{ iconName: "Like" }}
+                    title={t("Good response")}
+                    onClick={() => handleFeedback(1)}
+                    disabled={!traceId || props.isStreaming}
+                />
+                <IconButton
+                    style={{ color: "black" }}
+                    iconProps={{ iconName: "Dislike" }}
+                    title={t("Bad response")}
+                    onClick={() => handleFeedback(0)}
+                    disabled={!traceId || props.isStreaming}
+                />
+            </>
+        );
+    };
+
     return (
-        <Stack className={`${styles.answerContainer} ${isSelected && styles.selected}`} verticalAlign="space-between">
+        <Stack className={`${styles.answerContainer} ${props.isSelected && styles.selected}`} verticalAlign="space-between">
             <Stack.Item>
                 <Stack horizontal horizontalAlign="space-between">
                     <AnswerIcon />
                     <div>
+                        {renderFeedbackButton()}
                         <IconButton
                             style={{ color: "black" }}
                             iconProps={{ iconName: copied ? "CheckMark" : "Copy" }}
@@ -79,7 +243,7 @@ export const Answer = ({
                             iconProps={{ iconName: "Lightbulb" }}
                             title={t("tooltips.showThoughtProcess")}
                             ariaLabel={t("tooltips.showThoughtProcess")}
-                            onClick={() => onThoughtProcessClicked()}
+                            onClick={() => props.onThoughtProcessClicked()}
                             disabled={!answer.context.thoughts?.length}
                         />
                         <IconButton
@@ -87,13 +251,18 @@ export const Answer = ({
                             iconProps={{ iconName: "ClipboardList" }}
                             title={t("tooltips.showSupportingContent")}
                             ariaLabel={t("tooltips.showSupportingContent")}
-                            onClick={() => onSupportingContentClicked()}
+                            onClick={() => props.onSupportingContentClicked()}
                             disabled={!answer.context.data_points}
                         />
-                        {showSpeechOutputAzure && (
-                            <SpeechOutputAzure answer={sanitizedAnswerHtml} index={index} speechConfig={speechConfig} isStreaming={isStreaming} />
+                        {props.showSpeechOutputAzure && (
+                            <SpeechOutputAzure
+                                answer={sanitizedAnswerHtml}
+                                index={props.index}
+                                speechConfig={props.speechConfig}
+                                isStreaming={props.isStreaming}
+                            />
                         )}
-                        {showSpeechOutputBrowser && <SpeechOutputBrowser answer={sanitizedAnswerHtml} />}
+                        {props.showSpeechOutputBrowser && <SpeechOutputBrowser answer={sanitizedAnswerHtml} />}
                     </div>
                 </Stack>
             </Stack.Item>
@@ -111,7 +280,7 @@ export const Answer = ({
                         {parsedAnswer.citations.map((x, i) => {
                             const path = getCitationFilePath(x);
                             return (
-                                <a key={i} className={styles.citation} title={x} onClick={() => onCitationClicked(path)}>
+                                <a key={i} className={styles.citation} title={x} onClick={() => props.onCitationClicked(path)}>
                                     {`${++i}. ${x}`}
                                 </a>
                             );
@@ -120,17 +289,20 @@ export const Answer = ({
                 </Stack.Item>
             )}
 
-            {!!followupQuestions?.length && showFollowupQuestions && onFollowupQuestionClicked && (
+            {!!followupQuestions?.length && props.showFollowupQuestions && props.onFollowupQuestionClicked && (
                 <Stack.Item>
                     <Stack horizontal wrap className={`${!!parsedAnswer.citations.length ? styles.followupQuestionsList : ""}`} tokens={{ childrenGap: 6 }}>
                         <span className={styles.followupQuestionLearnMore}>{t("followupQuestions")}</span>
-                        {followupQuestions.map((x, i) => {
-                            return (
-                                <a key={i} className={styles.followupQuestion} title={x} onClick={() => onFollowupQuestionClicked(x)}>
-                                    {`${x}`}
-                                </a>
-                            );
-                        })}
+                        {followupQuestions.map((x, i) => (
+                            <a
+                                key={i}
+                                className={styles.followupQuestion}
+                                title={x}
+                                onClick={() => props.onFollowupQuestionClicked && props.onFollowupQuestionClicked(x)}
+                            >
+                                {x}
+                            </a>
+                        ))}
                     </Stack>
                 </Stack.Item>
             )}

--- a/app/frontend/src/components/Answer/FeedbackContext.tsx
+++ b/app/frontend/src/components/Answer/FeedbackContext.tsx
@@ -1,0 +1,135 @@
+import { createContext, useContext, useState, useCallback, useEffect, useRef } from "react";
+import { openDB, IDBPDatabase } from "idb";
+
+type FeedbackState = {
+    [traceId: string]: number;
+};
+
+interface FeedbackContextType {
+    feedbackState: FeedbackState;
+    setFeedback: (traceId: string, value: number) => Promise<void>;
+    loadSavedFeedback: (traceId: string) => Promise<number | null>;
+}
+
+const FeedbackContext = createContext<FeedbackContextType>({
+    feedbackState: {},
+    setFeedback: async () => {},
+    loadSavedFeedback: async () => null
+});
+
+export const FeedbackProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [feedbackState, setFeedbackState] = useState<FeedbackState>({});
+    const dbRef = useRef<IDBPDatabase>();
+    const initialized = useRef(false);
+
+    // Consolidated cleanup function
+    const cleanup = useCallback(() => {
+        if (dbRef.current) {
+            dbRef.current.close();
+        }
+        initialized.current = false;
+        // Don't reset state on every cleanup - only when component unmounts
+    }, []);
+
+    // Single useEffect for initialization and cleanup
+    useEffect(() => {
+        const init = async () => {
+            if (initialized.current) return;
+
+            try {
+                const db = await openDB("feedback-store", 1, {
+                    upgrade(db) {
+                        if (!db.objectStoreNames.contains("feedback")) {
+                            db.createObjectStore("feedback");
+                        }
+                    }
+                });
+                dbRef.current = db;
+
+                // Load existing feedback
+                const tx = db.transaction("feedback", "readonly");
+                const store = tx.objectStore("feedback");
+                const keys = await store.getAllKeys();
+                const values = await Promise.all(
+                    keys.map(async key => ({
+                        key: key as string,
+                        value: await store.get(key)
+                    }))
+                );
+
+                // Update state with existing feedback
+                const newState: FeedbackState = {};
+                values.forEach(({ key, value }) => {
+                    if (value !== undefined) {
+                        newState[key] = value;
+                    }
+                });
+
+                setFeedbackState(newState);
+                initialized.current = true;
+                console.log("Feedback store initialized with:", newState);
+            } catch (error) {
+                console.error("Failed to initialize feedback store:", error);
+            }
+        };
+
+        init();
+
+        // Only reset state when component is unmounted
+        return () => {
+            cleanup();
+            setFeedbackState({});
+        };
+    }, [cleanup]);
+
+    const setFeedback = useCallback(async (traceId: string, value: number) => {
+        if (!dbRef.current) {
+            throw new Error("Feedback store not initialized");
+        }
+
+        try {
+            // Update DB first
+            await dbRef.current.put("feedback", value, traceId);
+
+            // Only update state if DB operation succeeded
+            setFeedbackState(prev => {
+                const newState = { ...prev, [traceId]: value };
+                console.log(`Updated feedback state for ${traceId}:`, newState);
+                return newState;
+            });
+        } catch (error) {
+            console.error(`Failed to set feedback for ${traceId}:`, error);
+            throw error;
+        }
+    }, []);
+
+    const loadSavedFeedback = useCallback(
+        async (traceId: string): Promise<number | null> => {
+            // Check memory state first
+            if (feedbackState[traceId] !== undefined) {
+                return feedbackState[traceId];
+            }
+
+            if (!dbRef.current) {
+                console.warn("Feedback store not initialized");
+                return null;
+            }
+
+            try {
+                const value = await dbRef.current.get("feedback", traceId);
+                if (value !== undefined) {
+                    setFeedbackState(prev => ({ ...prev, [traceId]: value }));
+                }
+                return value ?? null;
+            } catch (error) {
+                console.error(`Failed to load feedback for ${traceId}:`, error);
+                return null;
+            }
+        },
+        [feedbackState]
+    );
+
+    return <FeedbackContext.Provider value={{ feedbackState, setFeedback, loadSavedFeedback }}>{children}</FeedbackContext.Provider>;
+};
+
+export const useFeedback = () => useContext(FeedbackContext);

--- a/app/frontend/src/components/Answer/FeedbackDialog.tsx
+++ b/app/frontend/src/components/Answer/FeedbackDialog.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { Dialog, DialogType, TextField, DefaultButton, PrimaryButton, Stack } from "@fluentui/react";
+
+interface FeedbackDialogProps {
+    isOpen: boolean;
+    value: number;
+    onDismiss: () => void;
+    onSubmit: (comment: string) => void;
+}
+
+export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ isOpen, value, onDismiss, onSubmit }) => {
+    const [comment, setComment] = React.useState("");
+
+    const handleSubmit = () => {
+        onSubmit(comment);
+        setComment(""); // Reset comment after submission
+    };
+
+    return (
+        <Dialog
+            hidden={!isOpen}
+            onDismiss={onDismiss}
+            dialogContentProps={{
+                type: DialogType.normal,
+                title: value === 1 ? "Positive Feedback" : "Negative Feedback"
+            }}
+            modalProps={{
+                isBlocking: false,
+                styles: { main: { maxWidth: 450 } }
+            }}
+        >
+            <Stack tokens={{ childrenGap: 20 }}>
+                <TextField
+                    multiline
+                    rows={3}
+                    value={comment}
+                    onChange={(_, newValue) => setComment(newValue || "")}
+                    placeholder="Comments (optional)"
+                    label="Enter your feedback"
+                />
+                <Stack horizontal tokens={{ childrenGap: 10 }} horizontalAlign="end">
+                    <DefaultButton onClick={() => onSubmit("")} text="Skip Comment" />
+                    <PrimaryButton onClick={handleSubmit} text="Submit" disabled={!comment.trim()} />
+                </Stack>
+            </Stack>
+        </Dialog>
+    );
+};

--- a/app/frontend/src/components/Answer/FeedbackStore.ts
+++ b/app/frontend/src/components/Answer/FeedbackStore.ts
@@ -1,0 +1,140 @@
+import { openDB, IDBPDatabase } from "idb";
+
+export class FeedbackStore {
+    private static instance: FeedbackStore;
+    private readonly dbName = "ChatFeedbackDB";
+    private readonly storeName = "feedback";
+    private dbPromise: Promise<IDBDatabase>;
+    private memoryCache: Map<string, number> = new Map();
+    private initPromise: Promise<void>;
+    private initialized = false;
+
+    private constructor() {
+        this.dbPromise = this.initializeDB();
+        this.initPromise = this.loadAllFeedback();
+    }
+
+    public static getInstance(): FeedbackStore {
+        if (!FeedbackStore.instance) {
+            FeedbackStore.instance = new FeedbackStore();
+        }
+        return FeedbackStore.instance;
+    }
+
+    private initializeDB(): Promise<IDBDatabase> {
+        return new Promise((resolve, reject) => {
+            const request = indexedDB.open(this.dbName, 1);
+
+            request.onerror = () => reject(request.error);
+
+            request.onupgradeneeded = event => {
+                const db = (event.target as IDBOpenDBRequest).result;
+                if (!db.objectStoreNames.contains(this.storeName)) {
+                    db.createObjectStore(this.storeName);
+                }
+            };
+
+            request.onsuccess = () => resolve(request.result);
+        });
+    }
+
+    private async loadAllFeedback(): Promise<void> {
+        if (this.initialized) return;
+
+        try {
+            const db = await this.dbPromise;
+            const tx = db.transaction(this.storeName, "readonly");
+            const store = tx.objectStore(this.storeName);
+            const keys = await new Promise<string[]>((resolve, reject) => {
+                const request = store.getAllKeys();
+                request.onsuccess = () => resolve(request.result as string[]);
+                request.onerror = () => reject(request.error);
+            });
+            const values = await Promise.all(
+                keys.map(async key => ({
+                    key: key as string,
+                    value: await new Promise<number | undefined>((resolve, reject) => {
+                        const request = store.get(key);
+                        request.onsuccess = () => resolve(request.result);
+                        request.onerror = () => reject(request.error);
+                    })
+                }))
+            );
+
+            values.forEach(({ key, value }) => {
+                if (value !== undefined) {
+                    this.memoryCache.set(key, value);
+                }
+            });
+
+            console.log("Loaded feedback cache:", Object.fromEntries(this.memoryCache));
+            this.initialized = true;
+        } catch (error) {
+            console.error("Failed to load feedback cache:", error);
+            throw error;
+        }
+    }
+
+    private async ensureInitialized(): Promise<void> {
+        if (this.initialized) return;
+        await this.initPromise;
+    }
+
+    async getFeedback(traceId: string): Promise<number | null> {
+        await this.ensureInitialized();
+
+        // First check memory cache
+        const cached = this.memoryCache.get(traceId);
+        if (cached !== undefined) {
+            return cached;
+        }
+
+        try {
+            const db = await this.dbPromise;
+            const request = await db.transaction(this.storeName).objectStore(this.storeName).get(traceId);
+
+            const value = request.result;
+
+            if (value !== undefined) {
+                this.memoryCache.set(traceId, value);
+            }
+            return value ?? null;
+        } catch (error) {
+            console.error(`Error getting feedback for ${traceId}:`, error);
+            return null;
+        }
+    }
+
+    async setFeedback(traceId: string, value: number): Promise<void> {
+        await this.initPromise;
+
+        try {
+            const db = await this.dbPromise;
+            const transaction = db.transaction(this.storeName, "readwrite");
+            const store = transaction.objectStore(this.storeName);
+
+            return new Promise((resolve, reject) => {
+                const request = store.put(value, traceId);
+
+                request.onsuccess = () => {
+                    this.memoryCache.set(traceId, value);
+                    console.log(`FeedbackStore: Stored feedback=${value} for ${traceId}`);
+                    resolve();
+                };
+
+                request.onerror = () => {
+                    console.error(`FeedbackStore: Failed to store feedback=${value} for ${traceId}`, request.error);
+                    reject(request.error);
+                };
+            });
+        } catch (error) {
+            this.memoryCache.delete(traceId); // Remove from cache if storage fails
+            throw error;
+        }
+    }
+
+    async getAllFeedback(): Promise<Map<string, number>> {
+        await this.initPromise;
+        return new Map(this.memoryCache);
+    }
+}

--- a/app/frontend/src/components/Answer/index.ts
+++ b/app/frontend/src/components/Answer/index.ts
@@ -3,3 +3,4 @@ export * from "./AnswerLoading";
 export * from "./AnswerError";
 export * from "./SpeechOutputBrowser";
 export * from "./SpeechOutputAzure";
+export * from "./FeedbackContext";

--- a/app/frontend/src/components/Answer/index.ts
+++ b/app/frontend/src/components/Answer/index.ts
@@ -4,3 +4,4 @@ export * from "./AnswerError";
 export * from "./SpeechOutputBrowser";
 export * from "./SpeechOutputAzure";
 export * from "./FeedbackContext";
+export * from "./FeedbackDialog";

--- a/app/frontend/src/components/HistoryProviders/CosmosDB.ts
+++ b/app/frontend/src/components/HistoryProviders/CosmosDB.ts
@@ -48,4 +48,19 @@ export class CosmosDBProvider implements IHistoryProvider {
         await deleteChatHistoryApi(id, idToken || "");
         return;
     }
+
+    async updateFeedback(id: string, feedback: number): Promise<void> {
+        // Assuming you have an API endpoint for updating feedback in CosmosDB
+        try {
+            await fetch(`/api/history/${id}/feedback`, {
+                method: "PUT",
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify({ feedback })
+            });
+        } catch (error) {
+            console.error("Error updating feedback in CosmosDB:", error);
+        }
+    }
 }

--- a/app/frontend/src/components/HistoryProviders/FeedbackStore.ts
+++ b/app/frontend/src/components/HistoryProviders/FeedbackStore.ts
@@ -1,0 +1,145 @@
+import { openDB, IDBPDatabase } from "idb";
+
+export class FeedbackStore {
+    private static instance: FeedbackStore;
+    private readonly dbName = "ChatFeedbackDB";
+    private readonly storeName = "feedback";
+    private dbPromise: Promise<IDBDatabase>;
+    private memoryCache: Map<string, number> = new Map();
+    private initPromise: Promise<void>;
+    private initialized = false;
+
+    private constructor() {
+        this.dbPromise = this.initializeDB();
+        this.initPromise = this.loadAllFeedback();
+    }
+
+    public static getInstance(): FeedbackStore {
+        if (!FeedbackStore.instance) {
+            FeedbackStore.instance = new FeedbackStore();
+        }
+        return FeedbackStore.instance;
+    }
+
+    private initializeDB(): Promise<IDBDatabase> {
+        return new Promise((resolve, reject) => {
+            const request = indexedDB.open(this.dbName, 1);
+
+            request.onerror = () => reject(request.error);
+
+            request.onupgradeneeded = event => {
+                const db = (event.target as IDBOpenDBRequest).result;
+                if (!db.objectStoreNames.contains(this.storeName)) {
+                    db.createObjectStore(this.storeName);
+                }
+            };
+
+            request.onsuccess = () => resolve(request.result);
+        });
+    }
+
+    private async loadAllFeedback(): Promise<void> {
+        if (this.initialized) return;
+
+        try {
+            const db = await this.dbPromise;
+            const tx = db.transaction(this.storeName, "readonly");
+            const store = tx.objectStore(this.storeName);
+            const keys = await new Promise<string[]>((resolve, reject) => {
+                const request = store.getAllKeys();
+                request.onsuccess = () => resolve(request.result as string[]);
+                request.onerror = () => reject(request.error);
+            });
+            const values = await Promise.all(
+                keys.map(async key => ({
+                    key: key as string,
+                    value: await new Promise<number | undefined>((resolve, reject) => {
+                        const request = store.get(key);
+                        request.onsuccess = () => resolve(request.result);
+                        request.onerror = () => reject(request.error);
+                    })
+                }))
+            );
+
+            values.forEach(({ key, value }) => {
+                if (value !== undefined) {
+                    this.memoryCache.set(key, value);
+                }
+            });
+
+            console.log("Loaded feedback cache:", Object.fromEntries(this.memoryCache));
+            this.initialized = true;
+        } catch (error) {
+            console.error("Failed to load feedback cache:", error);
+            throw error;
+        }
+    }
+
+    async getFeedback(traceId: string): Promise<number | null> {
+        await this.initPromise;
+
+        // Check memory cache first
+        if (this.memoryCache.has(traceId)) {
+            return this.memoryCache.get(traceId) ?? null;
+        }
+
+        try {
+            const db = await this.dbPromise;
+            const transaction = db.transaction(this.storeName, "readonly");
+            const store = transaction.objectStore(this.storeName);
+
+            return new Promise((resolve, reject) => {
+                const request = store.get(traceId);
+                request.onsuccess = () => {
+                    const value = request.result;
+                    if (value !== undefined) {
+                        this.memoryCache.set(traceId, value);
+                    }
+                    resolve(value ?? null);
+                };
+                request.onerror = () => reject(request.error);
+            });
+        } catch (error) {
+            console.error(`FeedbackStore: Error getting feedback for ${traceId}:`, error);
+            return null;
+        }
+    }
+
+    async setFeedback(traceId: string, value: number): Promise<void> {
+        await this.initPromise;
+
+        try {
+            const db = await this.dbPromise;
+            const transaction = db.transaction(this.storeName, "readwrite");
+            const store = transaction.objectStore(this.storeName);
+
+            // Return a promise that only resolves when transaction is complete
+            return new Promise((resolve, reject) => {
+                transaction.oncomplete = () => {
+                    this.memoryCache.set(traceId, value);
+                    console.log(`FeedbackStore: Transaction completed for ${traceId}, value=${value}`);
+                    resolve();
+                };
+
+                transaction.onerror = () => {
+                    console.error(`FeedbackStore: Transaction failed for ${traceId}`, transaction.error);
+                    reject(transaction.error);
+                };
+
+                const request = store.put(value, traceId);
+                request.onerror = () => {
+                    console.error(`FeedbackStore: Failed to store feedback=${value} for ${traceId}`, request.error);
+                    reject(request.error);
+                };
+            });
+        } catch (error) {
+            console.error(`FeedbackStore: Error setting feedback for ${traceId}:`, error);
+            throw error;
+        }
+    }
+
+    async getAllFeedback(): Promise<Map<string, number>> {
+        await this.initPromise;
+        return new Map(this.memoryCache);
+    }
+}

--- a/app/frontend/src/components/HistoryProviders/HistoryManager.ts
+++ b/app/frontend/src/components/HistoryProviders/HistoryManager.ts
@@ -1,11 +1,11 @@
 import { useMemo } from "react";
-import { IHistoryProvider, HistoryProviderOptions } from "../HistoryProviders/IProvider";
-import { NoneProvider } from "../HistoryProviders/None";
-import { IndexedDBProvider } from "../HistoryProviders/IndexedDB";
-import { CosmosDBProvider } from "../HistoryProviders/CosmosDB";
+import { IHistoryProvider, HistoryProviderOptions } from "./IProvider";
+import { NoneProvider } from "./None";
+import { IndexedDBProvider } from "./IndexedDB";
+import { CosmosDBProvider } from "./CosmosDB";
 
 export const useHistoryManager = (provider: HistoryProviderOptions): IHistoryProvider => {
-    const providerInstance = useMemo(() => {
+    return useMemo(() => {
         switch (provider) {
             case HistoryProviderOptions.IndexedDB:
                 return new IndexedDBProvider("chat-database", "chat-history");
@@ -16,6 +16,4 @@ export const useHistoryManager = (provider: HistoryProviderOptions): IHistoryPro
                 return new NoneProvider();
         }
     }, [provider]);
-
-    return providerInstance;
 };

--- a/app/frontend/src/components/HistoryProviders/IProvider.ts
+++ b/app/frontend/src/components/HistoryProviders/IProvider.ts
@@ -1,6 +1,11 @@
 import { ChatAppResponse } from "../../api";
 
-export type HistoryMetaData = { id: string; title: string; timestamp: number };
+export type HistoryMetaData = {
+    id: string;
+    title: string;
+    timestamp: number;
+    feedback?: number; // Add feedback field
+};
 export type Answers = [user: string, response: ChatAppResponse][];
 
 export const enum HistoryProviderOptions {
@@ -16,4 +21,17 @@ export interface IHistoryProvider {
     addItem(id: string, answers: Answers, idToken?: string): Promise<void>;
     getItem(id: string, idToken?: string): Promise<Answers | null>;
     deleteItem(id: string, idToken?: string): Promise<void>;
+    updateFeedback(id: string, feedback: number): Promise<void>; // Add this method
+}
+
+export interface IFeedbackProvider {
+    getFeedback(traceId: string): Promise<number | null>;
+    setFeedback(traceId: string, value: number): Promise<void>;
+    getAllFeedback(): Promise<Map<string, number>>;
+}
+
+export enum FeedbackProviderOptions {
+    None = "none",
+    IndexedDB = "indexeddb",
+    CosmosDB = "cosmosdb"
 }

--- a/app/frontend/src/components/HistoryProviders/None.ts
+++ b/app/frontend/src/components/HistoryProviders/None.ts
@@ -17,4 +17,7 @@ export class NoneProvider implements IHistoryProvider {
     async deleteItem(id: string): Promise<void> {
         return;
     }
+    async updateFeedback(_id: string, _feedback: number): Promise<void> {
+        return Promise.resolve();
+    }
 }

--- a/app/frontend/src/pages/chat/Chat.tsx
+++ b/app/frontend/src/pages/chat/Chat.tsx
@@ -52,7 +52,7 @@ const Chat = () => {
     const [useSemanticCaptions, setUseSemanticCaptions] = useState<boolean>(false);
     const [includeCategory, setIncludeCategory] = useState<string>("");
     const [excludeCategory, setExcludeCategory] = useState<string>("");
-    const [useSuggestFollowupQuestions, setUseSuggestFollowupQuestions] = useState<boolean>(false);
+    const [useSuggestFollowupQuestions, setUseSuggestFollowupQuestions] = useState<boolean>(true);
     const [vectorFieldList, setVectorFieldList] = useState<VectorFieldOptions[]>([VectorFieldOptions.Embedding]);
     const [useOidSecurityFilter, setUseOidSecurityFilter] = useState<boolean>(false);
     const [useGroupsSecurityFilter, setUseGroupsSecurityFilter] = useState<boolean>(false);
@@ -473,7 +473,7 @@ const Chat = () => {
                         isOpen={isHistoryPanelOpen}
                         notify={!isStreaming && !isLoading}
                         onClose={() => setIsHistoryPanelOpen(false)}
-                        onChatSelected={answers => {
+                        onChatSelected={(answers: [string, ChatAppResponse][]) => {
                             if (answers.length === 0) return;
                             setAnswers(answers);
                             lastQuestionRef.current = answers[answers.length - 1][0];


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This PR implements [Langfuse](https://github.com/langfuse/langfuse) integration for systematic tracking and analysis of user feedback on chat responses, enabling better monitoring and insights into user interactions.

https://github.com/user-attachments/assets/31dd1d19-2865-4f07-89f4-8d0b3f02a73c


## 🔄 Key Changes
* Added Langfuse SDK integration for feedback tracking
* Implemented unified feedback handling system
* Enhanced feedback UI with success/error notifications
* Added custom feedback state management hook
* Improved error handling and logging mechanisms

## 🛠️ Setup Required
Add to your `.env` file:
```bash
# Langfuse Configuration
LANGFUSE_HOST="https://cloud.langfuse.com"
LANGFUSE_PUBLIC_KEY="<your-langfuse-public-key>"
LANGFUSE_SECRET_KEY="<your-langfuse-secret-key>"
```

## ✅ Testing Checklist
1. [ ] Langfuse credentials configuration
2. [x] Positive/negative feedback submission
3. [ ] Langfuse data verification
   - [x] Verify correct feedback score values (1 for👍/0 for👎)
   - [x] Validate metadata (trace_id, timestamp, user_oid)
   - [ ] Check token count accuracy
   - [ ] Verify prompt and completion data
   - [ ] Confirm event types are properly labeled
   - [ ] Test response metrics(latency and etc)
4. [ ] Network error handling
5. [x] Local history functionality
6. [ ] Multi-language support for new strings
7. [ ] CosmosDB Integration Testing
   - [ ] Verify feedback sync with CosmosDB enabled
   - [ ] Test history retrieval with CosmosDB
   - [ ] Validate trace_id correlation in CosmosDB
   - [ ] Check feedback persistence across sessions
8. [ ] Verify optional feature functionality
   - [ ] Test with Langfuse disabled
   - [ ] Test with invalid credentials
   - [ ] Test fallback to local storage
   
## 📝 Important Notes
* Requires Langfuse account setup for analytics features
* Dual storage implementation:
  * Local: Always stored in IndexedDB/browser storage
  * Langfuse: Optional remote analytics storage when configured
* Uses trace IDs for feedback correlation
* Needs additional testing for non-Langfuse mode
* Optional feature - system continues to work with local storage only

Please verify your Langfuse credentials before deploying to production.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[ ] No
```
Verify if this produces errors when:
- [x] Running local dev server
- [ ] Running `azd up`
- [ ] Running `azd deploy`
- [ ] Running in existing environments

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[x] No (?)
```

## Type of change

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
