### PR TITLE
Clearer variables for image cropping code

### DIFF
--- a/app/backend/prepdocslib/pdfparser.py
+++ b/app/backend/prepdocslib/pdfparser.py
@@ -224,25 +224,25 @@ class DocumentAnalysisParser(Parser):
 
     @staticmethod
     def crop_image_from_pdf_page(
-        doc: pymupdf.Document, page_number: int, bounding_box: tuple[float, float, float, float]
+        doc: pymupdf.Document, page_number: int, bbox_inches: tuple[float, float, float, float]
     ) -> bytes:
         """
         Crops a region from a given page in a PDF and returns it as an image.
 
         :param pdf_path: Path to the PDF file.
         :param page_number: The page number to crop from (0-indexed).
-        :param bounding_box: A tuple of (x0, y0, x1, y1) coordinates for the bounding box.
+        :param bbox_inches: A tuple of (x0, y0, x1, y1) coordinates for the bounding box, in inches.
         :return: A PIL Image of the cropped area.
         """
+        # Scale the bounding box to 72 DPI
+        bbox_dpi = 72
+        bbox_pixels = [x * bbox_dpi for x in bbox_inches]
+        rect = pymupdf.Rect(bbox_pixels)
+        # Assume that the PDF has 300 DPI,
+        # and use the matrix to convert between the 2 DPIs
+        page_dpi = 300
         page = doc.load_page(page_number)
-
-        # Cropping the page. The rect requires the coordinates in the format (x0, y0, x1, y1).
-        bbx = [x * 72 for x in bounding_box]
-        rect = pymupdf.Rect(bbx)
-        # Bounding box is scaled to 72 dots per inch
-        # We assume the PDF has 300 DPI
-        # The matrix is used to convert between these 2 units
-        pix = page.get_pixmap(matrix=pymupdf.Matrix(300 / 72, 300 / 72), clip=rect)
+        pix = page.get_pixmap(matrix=pymupdf.Matrix(page_dpi / bbox_dpi, page_dpi / bbox_dpi), clip=rect)
 
         img = Image.frombytes("RGB", (pix.width, pix.height), pix.samples)
         bytes_io = io.BytesIO()


### PR DESCRIPTION
## Purpose

This is a tiny PR, I just reamed the variables/reworded comments when I was explaining the image cropping in the recent stream.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[X] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
