### PR TITLE
Note about ACA and app insights

### DIFF
--- a/docs/deploy_lowcost.md
+++ b/docs/deploy_lowcost.md
@@ -92,7 +92,9 @@ However, if your goal is to minimize costs while prototyping your application, f
 
     Limitation: You can have only one free Cosmos DB account. To keep your account free of charge, ensure that you do not exceed the free tier limits. For more information, see the [Azure Cosmos DB lifetime free tier](https://learn.microsoft.com/azure/cosmos-db/free-tier).
 
-1. Turn off Azure Monitor (Application Insights):
+1. ⚠️ This step is currently only possible if you're deploying to App Service ([see issue 2281](https://github.com/Azure-Samples/azure-search-openai-demo/issues/2281)):
+
+    Turn off Azure Monitor (Application Insights):
 
     ```shell
     azd env set AZURE_USE_APPLICATION_INSIGHTS false


### PR DESCRIPTION
## Purpose

Adds documentation about #2281 issue, Container Apps doesn't allow App Insights to be turned off.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[X] Yes
[ ] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

