### PR TITLE
Use uv managed python in GHA workflows

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -26,21 +26,15 @@ jobs:
       matrix:
         os: ["ubuntu-20.04", "windows-latest"]
         python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-    env:
-      UV_SYSTEM_PYTHON: 1
     steps:
         - uses: actions/checkout@v4
-        - name: Setup python
-          uses: actions/setup-python@v5
-          with:
-            python-version: ${{ matrix.python_version }}
-            architecture: x64
         - name: Install uv
           uses: astral-sh/setup-uv@v5
           with:
             enable-cache: true
             version: "0.4.20"
             cache-dependency-glob: "requirements**.txt"
+            python-version: ${{ matrix.python_version }}
         - name: Setup node
           uses: actions/setup-node@v4
           with:
@@ -58,20 +52,20 @@ jobs:
         - name: Check types with mypy
           run: |
             cd scripts/
-            python3 -m mypy . --config-file=../pyproject.toml
+            mypy . --config-file=../pyproject.toml
             cd ../app/backend/
-            python3 -m mypy . --config-file=../../pyproject.toml
+            mypy . --config-file=../../pyproject.toml
         - name: Check formatting with black
           run: black . --check --verbose
         - name: Run Python tests
           if: runner.os != 'Windows'
-          run: python3 -m pytest -s -vv --cov --cov-fail-under=86
+          run: pytest -s -vv --cov --cov-fail-under=86
         - name: Run E2E tests with Playwright
           id: e2e
           if: runner.os != 'Windows'
           run: |
             playwright install chromium --with-deps
-            python3 -m pytest tests/e2e.py --tracing=retain-on-failure
+            pytest tests/e2e.py --tracing=retain-on-failure
         - name: Upload test artifacts
           if: ${{ failure() && steps.e2e.conclusion == 'failure' }}
           uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Purpose

Less overhead makes this easier to maintain and enables using hardlinking on Windows runners

The hardlinking warning can be seen here.
https://github.com/Azure-Samples/azure-search-openai-demo/actions/runs/13211586770/job/36885643258
<img width="880" alt="grafik" src="https://github.com/user-attachments/assets/cc17bac1-72b2-4c9a-a112-b39969a425c3" />


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
