### PR TITLE
Add quotes to azd env set

### DIFF
--- a/scripts/auth_init.py
+++ b/scripts/auth_init.py
@@ -81,7 +81,7 @@ async def create_or_update_application_with_secret(
 
 
 def update_azd_env(name, val):
-    subprocess.run(f"azd env set {name} {val}", shell=True)
+    subprocess.run(f'azd env set {name} "{val}"', shell=True)
 
 
 def random_app_identifier():


### PR DESCRIPTION
## Purpose

* Quote parameter when running `azd env set` during auth setup
* This prevents env variables from being interpreted as command line switches, for example when setting values that have `-` in them

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
