### PR TITLE
Update searchmanager.py

### DIFF
--- a/app/backend/prepdocslib/searchmanager.py
+++ b/app/backend/prepdocslib/searchmanager.py
@@ -141,6 +141,8 @@ class SearchManager:
                 if self.use_int_vectorization:
                     logger.info("Including parent_id field in new index %s", self.search_info.index_name)
                     fields.append(SearchableField(name="parent_id", type="Edm.String", filterable=True))
+                    logger.info("Including title field in new index %s", self.search_info.index_name)
+                    fields.append(SimpleField(name="title", type="Edm.String", searchable=True, retrievable=True))
                 if self.search_images:
                     logger.info("Including imageEmbedding field in new index %s", self.search_info.index_name)
                     fields.append(


### PR DESCRIPTION
Integrated vectorizer needs a title field in the index which is not defined while creating the initial index..

## Purpose

Fixes the index when integrated vectorization is enabled.


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X ] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X ] No
```

## Type of change

```
[X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
