### PR TITLE
use hypercorn instead of gunicorn

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -449,7 +449,7 @@ module backend 'core/host/appservice.bicep' = if (deploymentTarget == 'appservic
     appServicePlanId: deploymentTarget == 'appservice' ? appServicePlan.outputs.id : ''
     runtimeName: 'python'
     runtimeVersion: '3.11'
-    appCommandLine: 'python3 -m gunicorn main:app'
+    appCommandLine: 'hypercorn -b "0.0.0.0:8000" main:app'
     scmDoBuildDuringDeployment: true
     managedIdentity: true
     virtualNetworkSubnetId: isolation.outputs.appSubnetId


### PR DESCRIPTION
## Purpose

Resolves issue #2405 by using hypercorn instead of gunicorn in startup command.


## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
