### PR TITLE
Upgrade Ubuntu runner for tests in Github Workflow to `latest`

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-24.04", "windows-latest"]
+        os: ["ubuntu-latest", "windows-latest"]
         python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
         - uses: actions/checkout@v4

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04", "windows-latest"]
+        os: ["ubuntu-22.04", "windows-latest"]
         python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
         - uses: actions/checkout@v4

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "windows-latest"]
+        os: ["ubuntu-24.04", "windows-latest"]
         python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
         - uses: actions/checkout@v4


### PR DESCRIPTION
## Purpose

GitHub Actions deprecates `ubuntu-20.04` image. The image will be fully unsupported by 2025-04-01.
Here is more information: https://github.com/actions/runner-images/issues/11101

This PR changes the version of Ubuntu runner to the latest LTS release 24.04.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Dependency upgrade
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
