### PR TITLE
Add login troubleshooting steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,30 @@ It will look like the following:
 
 > NOTE: It may take 5-10 minutes after you see 'SUCCESS' for the application to be fully deployed. If you see a "Python Developer" welcome screen or an error page, then wait a bit and refresh the page.
 
+### Login error troubleshooting
+
+If you encounter a login error or need to switch to a different account, follow these steps:
+
+1. ** Log out of the current session**:
+
+```shell
+az logout
+```
+2. Log in again:
+
+```shell
+az login
+```
+Opens a browser to authenticate.
+
+3. Verify account:
+
+```shell
+az account show
+```
+Confirms your active account details.
+
+
 ### Deploying again
 
 If you've only changed the backend/frontend code in the `app` folder, then you don't need to re-provision the Azure resources. You can just run:

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ The steps below will provision Azure resources and deploy the application code t
     ```shell
     azd auth login
     ```
-
+    
     For GitHub Codespaces users, if the previous command fails, try:
 
    ```shell
@@ -187,16 +187,18 @@ It will look like the following:
 
 If you encounter a login error or need to switch to a different account, follow these steps:
 
-1. ** Log out of the current session**:
+1. Log out of the current session:
 
 ```shell
 az logout
 ```
+
 2. Log in again:
 
 ```shell
 az login
 ```
+
 Opens a browser to authenticate.
 
 3. Verify account:
@@ -204,8 +206,8 @@ Opens a browser to authenticate.
 ```shell
 az account show
 ```
-Confirms your active account details.
 
+Confirms your active account details.
 
 ### Deploying again
 


### PR DESCRIPTION
## Purpose

This PR adds a "Login Error Troubleshooting" section under "Deploying" in the README. It helps users resolve login issues during deployment by providing steps to log out, log in, and verify their account.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
