### PR TITLE
Adjust container apps to scale to zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The repo includes sample data so it's ready to try end to end. In this sample ap
 Pricing varies per region and usage, so it isn't possible to predict exact costs for your usage.
 However, you can try the [Azure pricing calculator](https://azure.com/e/e3490de2372a4f9b909b0d032560e41b) for the resources below.
 
-- Azure Container Apps: Default host for app deployment as of 10/28/2024. See more details in [the ACA deployment guide](docs/azure_container_apps.md). Consumption plan with 0.5 CPU core, 1.0 GB RAM, minimum of 0 replicas. Pricing with Pay-as-You-Go. [Pricing](https://azure.microsoft.com/pricing/details/container-apps/)
+- Azure Container Apps: Default host for app deployment as of 10/28/2024. See more details in [the ACA deployment guide](docs/azure_container_apps.md). Consumption plan with 1 CPU core, 2 GB RAM, minimum of 0 replicas. Pricing with Pay-as-You-Go. [Pricing](https://azure.microsoft.com/pricing/details/container-apps/)
 - Azure Container Registry: Basic tier. [Pricing](https://azure.microsoft.com/pricing/details/container-registry/)
 - Azure App Service: Only provisioned if you deploy to Azure App Service following [the App Service deployment guide](docs/azure_app_service.md).  Basic Tier with 1 CPU core, 1.75 GB RAM. Pricing per hour. [Pricing](https://azure.microsoft.com/pricing/details/app-service/linux/)
 - Azure OpenAI: Standard tier, GPT and Ada models. Pricing per 1K tokens used, and at least 1K tokens are used per question. [Pricing](https://azure.microsoft.com/pricing/details/cognitive-services/openai-service/)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The repo includes sample data so it's ready to try end to end. In this sample ap
 Pricing varies per region and usage, so it isn't possible to predict exact costs for your usage.
 However, you can try the [Azure pricing calculator](https://azure.com/e/e3490de2372a4f9b909b0d032560e41b) for the resources below.
 
-- Azure Container Apps: Default host for app deployment as of 10/28/2024. See more details in [the ACA deployment guide](docs/azure_container_apps.md). Consumption plan with 1 CPU core, 2.0 GB RAM. Pricing with Pay-as-You-Go. [Pricing](https://azure.microsoft.com/pricing/details/container-apps/)
+- Azure Container Apps: Default host for app deployment as of 10/28/2024. See more details in [the ACA deployment guide](docs/azure_container_apps.md). Consumption plan with 0.5 CPU core, 1.0 GB RAM, minimum of 0 replicas. Pricing with Pay-as-You-Go. [Pricing](https://azure.microsoft.com/pricing/details/container-apps/)
 - Azure Container Registry: Basic tier. [Pricing](https://azure.microsoft.com/pricing/details/container-registry/)
 - Azure App Service: Only provisioned if you deploy to Azure App Service following [the App Service deployment guide](docs/azure_app_service.md).  Basic Tier with 1 CPU core, 1.75 GB RAM. Pricing per hour. [Pricing](https://azure.microsoft.com/pricing/details/app-service/linux/)
 - Azure OpenAI: Standard tier, GPT and Ada models. Pricing per 1K tokens used, and at least 1K tokens are used per question. [Pricing](https://azure.microsoft.com/pricing/details/cognitive-services/openai-service/)

--- a/docs/productionizing.md
+++ b/docs/productionizing.md
@@ -75,6 +75,15 @@ We recommend using a Premium level SKU, starting with 1 CPU core.
 You can use auto-scaling rules or scheduled scaling rules,
 and scale up the maximum/minimum based on load.
 
+### Azure Container Apps
+
+The default container app uses a "Consumption" workload profile with 0.5 CPU cores and 1.0 GB RAM,
+and scaling rules that allow for scaling all the way down to 0 replicas when idle.
+For production, consider either increasing the CPU cores and memory or
+[switching to a "Dedicated" workload profile](azure_container_apps.md#customizing-workload-profile),
+and configure the scaling rules to keep at least two replicas running at all times.
+Learn more in the [Azure Container Apps documentation](https://learn.microsoft.com/azure/container-apps).
+
 ## Additional security measures
 
 * **Authentication**: By default, the deployed app is publicly accessible.

--- a/docs/productionizing.md
+++ b/docs/productionizing.md
@@ -77,7 +77,7 @@ and scale up the maximum/minimum based on load.
 
 ### Azure Container Apps
 
-The default container app uses a "Consumption" workload profile with 0.5 CPU cores and 1.0 GB RAM,
+The default container app uses a "Consumption" workload profile with 1 CPU core and 2 GB RAM,
 and scaling rules that allow for scaling all the way down to 0 replicas when idle.
 For production, consider either increasing the CPU cores and memory or
 [switching to a "Dedicated" workload profile](azure_container_apps.md#customizing-workload-profile),

--- a/infra/core/host/container-app-upsert.bicep
+++ b/infra/core/host/container-app-upsert.bicep
@@ -14,8 +14,7 @@ param containerMaxReplicas int = 10
 @description('The amount of memory allocated to a single container instance, e.g., 1Gi')
 param containerMemory string = '1.0Gi'
 
-@description('The minimum number of replicas to run. Must be at least 1.')
-@minValue(1)
+@description('The minimum number of replicas to run. Must be at least 1 for non-consumption workloads.')
 param containerMinReplicas int = 1
 
 @description('The name of the container')

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -515,8 +515,8 @@ module acaBackend 'core/host/container-app-upsert.bicep' = if (deploymentTarget 
     identityType: 'UserAssigned'
     tags: union(tags, { 'azd-service-name': 'backend' })
     targetPort: 8000
-    containerCpuCoreCount: '0.5'
-    containerMemory: '1Gi'
+    containerCpuCoreCount: '1.0'
+    containerMemory: '2Gi'
     containerMinReplicas: 0
     allowedOrigins: allowedOrigins
     env: union(appEnvVariables, {

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -515,8 +515,9 @@ module acaBackend 'core/host/container-app-upsert.bicep' = if (deploymentTarget 
     identityType: 'UserAssigned'
     tags: union(tags, { 'azd-service-name': 'backend' })
     targetPort: 8000
-    containerCpuCoreCount: '1.0'
-    containerMemory: '2Gi'
+    containerCpuCoreCount: '0.5'
+    containerMemory: '1Gi'
+    containerMinReplicas: 0
     allowedOrigins: allowedOrigins
     env: union(appEnvVariables, {
       // For using managed identity to access Azure resources. See https://github.com/microsoft/azure-container-apps/issues/442


### PR DESCRIPTION
## Purpose

Fixes #2436 

Thanks to the filed issue, I discovered that we were configuring Container Apps with a higher-than-default CPU core and memory, and a min replica of 1.
Unfortunately, we need the higher CPU and memory, due to our app's needs,
but the app still works fine with a min replica of 0 - it just means a slower start when it needs to scale back to 1 sometimes.


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[X] Yes - If people are running this in production with these settings, it will reduce the performance of the app. I will note in release notes. I've also added a section to productionizing guide.
[ ] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

N/A, Bicep change