### PR TITLE
Resolve datetime deprecation warnings

### DIFF
--- a/tests/test_authenticationhelper.py
+++ b/tests/test_authenticationhelper.py
@@ -1,7 +1,7 @@
 import base64
 import json
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import aiohttp
 import jwt
@@ -53,9 +53,9 @@ def create_mock_jwt(kid="mock_kid", oid="OID_X"):
         "iss": "https://login.microsoftonline.com/TENANT_ID/v2.0",
         "sub": "AaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA",
         "aud": "SERVER_APP",
-        "exp": int((datetime.utcnow() + timedelta(hours=1)).timestamp()),
-        "iat": int(datetime.utcnow().timestamp()),
-        "nbf": int(datetime.utcnow().timestamp()),
+        "exp": int((datetime.now(timezone.utc) + timedelta(hours=1)).timestamp()),
+        "iat": int(datetime.now(timezone.utc).timestamp()),
+        "nbf": int(datetime.now(timezone.utc).timestamp()),
         "name": "John Doe",
         "oid": oid,
         "preferred_username": "john.doe@example.com",


### PR DESCRIPTION
## Purpose
This PR resolves `datetime` deprecation warnings which you can find in the [CI logs](https://github.com/Azure-Samples/azure-search-openai-demo/actions/runs/14526972722/job/40760250284#step:10:349):
```python
tests/test_authenticationhelper.py::test_validate_access_token
  /home/runner/work/azure-search-openai-demo/azure-search-openai-demo/tests/test_authenticationhelper.py:56: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    "exp": int((datetime.utcnow() + timedelta(hours=1)).timestamp()),

tests/test_authenticationhelper.py::test_validate_access_token
  /home/runner/work/azure-search-openai-demo/azure-search-openai-demo/tests/test_authenticationhelper.py:57: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    "iat": int(datetime.utcnow().timestamp()),

tests/test_authenticationhelper.py::test_validate_access_token
  /home/runner/work/azure-search-openai-demo/azure-search-openai-demo/tests/test_authenticationhelper.py:58: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    "nbf": int(datetime.utcnow().timestamp()),
```


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [x] I added tests that prove my fix is effective or that my feature works
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
