### PR TITLE
Disable ThoughtProcess/SupportingContent buttons during streaming

### DIFF
--- a/app/frontend/src/components/Answer/Answer.tsx
+++ b/app/frontend/src/components/Answer/Answer.tsx
@@ -80,7 +80,7 @@ export const Answer = ({
                             title={t("tooltips.showThoughtProcess")}
                             ariaLabel={t("tooltips.showThoughtProcess")}
                             onClick={() => onThoughtProcessClicked()}
-                            disabled={!answer.context.thoughts?.length}
+                            disabled={!answer.context.thoughts?.length || isStreaming}
                         />
                         <IconButton
                             style={{ color: "black" }}
@@ -88,7 +88,7 @@ export const Answer = ({
                             title={t("tooltips.showSupportingContent")}
                             ariaLabel={t("tooltips.showSupportingContent")}
                             onClick={() => onSupportingContentClicked()}
-                            disabled={!answer.context.data_points}
+                            disabled={!answer.context.data_points || isStreaming}
                         />
                         {showSpeechOutputAzure && (
                             <SpeechOutputAzure answer={sanitizedAnswerHtml} index={index} speechConfig={speechConfig} isStreaming={isStreaming} />


### PR DESCRIPTION
## Purpose

The changes ensure that the "Thought Process" and "Supporting Content" buttons are disabled while content is actively streaming.

![Screenshot 2025-05-27 at 2 11 43 PM](https://github.com/user-attachments/assets/5164cc51-7534-4c35-bebb-06a1d6b00df1)

In theory, it should be possible to see the Thought Process and Supporting Content as soon as the first chunk is streamed in that contains the context, but:

1) That would be a larger change as the AnalysisTab currently looks at the `answers` array which isn't populated until the stream finishes
2) In the future, I don't know that it would always be true that the first chunk contains the context, so it's better to wait until the stream finishes to show the Thought Process and Supporting Content. Or to make sure we're very specific about only enabling the viewing of whichever context has been streamed so far.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [X] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works - I don't think we have any e2e tests that check the mid-stream state.
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
