### PR TITLE
Updates to add latest omni models, upgrade package lock

### DIFF
--- a/app/backend/approaches/approach.py
+++ b/app/backend/approaches/approach.py
@@ -133,7 +133,9 @@ class Approach(ABC):
     # List of GPT reasoning models support
     GPT_REASONING_MODELS = {
         "o1": GPTReasoningModelSupport(streaming=False),
+        "o3": GPTReasoningModelSupport(streaming=True),
         "o3-mini": GPTReasoningModelSupport(streaming=True),
+        "o4-mini": GPTReasoningModelSupport(streaming=True),
     }
     # Set a higher token limit for GPT reasoning models
     RESPONSE_DEFAULT_TOKEN_LIMIT = 1024

--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -44,7 +44,7 @@
         "vite": "^5.4.18"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/docs/reasoning.md
+++ b/docs/reasoning.md
@@ -19,7 +19,27 @@ This repository includes an optional feature that uses reasoning models to gener
 
    Set the environment variables for your Azure OpenAI GPT deployments to your reasoning model
 
-   For o3-mini:
+   For o4-mini:
+
+   ```shell
+   azd env set AZURE_OPENAI_CHATGPT_MODEL o4-mini
+   azd env set AZURE_OPENAI_CHATGPT_DEPLOYMENT o4-mini
+   azd env set AZURE_OPENAI_CHATGPT_DEPLOYMENT_VERSION 2025-04-16
+   azd env set AZURE_OPENAI_CHATGPT_DEPLOYMENT_SKU GlobalStandard
+   azd env set AZURE_OPENAI_API_VERSION 2025-04-01-preview
+   ```
+
+   For o3:
+
+   ```shell
+   azd env set AZURE_OPENAI_CHATGPT_MODEL o3
+   azd env set AZURE_OPENAI_CHATGPT_DEPLOYMENT o3
+   azd env set AZURE_OPENAI_CHATGPT_DEPLOYMENT_VERSION 2025-04-16
+   azd env set AZURE_OPENAI_CHATGPT_DEPLOYMENT_SKU GlobalStandard
+   azd env set AZURE_OPENAI_API_VERSION 2025-04-01-preview
+   ```
+
+   For o3-mini: (No vision support)
 
    ```shell
    azd env set AZURE_OPENAI_CHATGPT_MODEL o3-mini
@@ -29,7 +49,7 @@ This repository includes an optional feature that uses reasoning models to gener
    azd env set AZURE_OPENAI_API_VERSION 2024-12-01-preview
    ```
 
-   For o1:
+   For o1: (No streaming support)
 
    ```shell
    azd env set AZURE_OPENAI_CHATGPT_MODEL o1


### PR DESCRIPTION
## Purpose

Adding o3 and o4-mini so that developers may use them without error.
Also upgraded package-lock to reflect package.json minimum node requirement.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
