### PR TITLE
Add support for GPT-5 model family

### DIFF
--- a/app/backend/approaches/approach.py
+++ b/app/backend/approaches/approach.py
@@ -136,6 +136,9 @@ class Approach(ABC):
         "o3": GPTReasoningModelSupport(streaming=True),
         "o3-mini": GPTReasoningModelSupport(streaming=True),
         "o4-mini": GPTReasoningModelSupport(streaming=True),
+        "gpt-5": GPTReasoningModelSupport(streaming=True),
+        "gpt-5-nano": GPTReasoningModelSupport(streaming=True),
+        "gpt-5-mini": GPTReasoningModelSupport(streaming=True),
     }
     # Set a higher token limit for GPT reasoning models
     RESPONSE_DEFAULT_TOKEN_LIMIT = 1024

--- a/docs/deploy_features.md
+++ b/docs/deploy_features.md
@@ -35,10 +35,16 @@ As of early June 2025, the default chat completion model is `gpt-4.1-mini`. If y
     For example:
 
     ```bash
-    azd env set AZURE_OPENAI_CHATGPT_DEPLOYMENT gpt-4o
+    azd env set AZURE_OPENAI_CHATGPT_DEPLOYMENT gpt-5-chat
     ```
 
-1. To set the GPT model to a different [available model](https://learn.microsoft.com/azure/ai-services/openai/concepts/models), run this command with the appropriate model name.
+1. To set the GPT model to a different [available model](https://learn.microsoft.com/azure/ai-services/openai/concepts/models), run this command with the appropriate model name. For reasoning models like gpt-5/o3/o4, check [the reasoning guide](./reasoning.md)
+
+   For gpt-5-chat:
+
+   ```shell
+   azd env set AZURE_OPENAI_CHATGPT_MODEL gpt-5-chat
+   ```
 
     For gpt-4.1-mini:
 
@@ -71,6 +77,12 @@ As of early June 2025, the default chat completion model is `gpt-4.1-mini`. If y
     ```
 
 1. To set the Azure OpenAI model version from the [available versions](https://learn.microsoft.com/azure/ai-services/openai/concepts/models), run this command with the appropriate version string.
+
+   For gpt-5-chat:
+
+   ```shell
+   azd env set AZURE_OPENAI_CHATGPT_DEPLOYMENT_VERSION 2025-08-07
+   ```
 
     For gpt-4.1-mini:
 

--- a/docs/reasoning.md
+++ b/docs/reasoning.md
@@ -6,6 +6,9 @@ This repository includes an optional feature that uses reasoning models to gener
 
 ### Supported Models
 
+* gpt-5
+* gpt-5-mini
+* gpt-5-nano
 * o4-mini
 * o3
 * o3-mini
@@ -20,6 +23,36 @@ This repository includes an optional feature that uses reasoning models to gener
 1. **Enable reasoning:**
 
    Set the environment variables for your Azure OpenAI GPT deployments to your reasoning model
+
+   For gpt-5:
+
+   ```shell
+   azd env set AZURE_OPENAI_CHATGPT_MODEL gpt-5
+   azd env set AZURE_OPENAI_CHATGPT_DEPLOYMENT gpt-5
+   azd env set AZURE_OPENAI_CHATGPT_DEPLOYMENT_VERSION 2025-08-07
+   azd env set AZURE_OPENAI_CHATGPT_DEPLOYMENT_SKU GlobalStandard
+   azd env set AZURE_OPENAI_API_VERSION 2025-04-01-preview
+   ```
+
+   For gpt-5-mini:
+
+   ```shell
+   azd env set AZURE_OPENAI_CHATGPT_MODEL gpt-5-mini
+   azd env set AZURE_OPENAI_CHATGPT_DEPLOYMENT gpt-5-mini
+   azd env set AZURE_OPENAI_CHATGPT_DEPLOYMENT_VERSION 2025-08-07
+   azd env set AZURE_OPENAI_CHATGPT_DEPLOYMENT_SKU GlobalStandard
+   azd env set AZURE_OPENAI_API_VERSION 2025-04-01-preview
+   ```
+
+   For gpt-5-nano:
+
+   ```shell
+   azd env set AZURE_OPENAI_CHATGPT_MODEL gpt-5-nano
+   azd env set AZURE_OPENAI_CHATGPT_DEPLOYMENT gpt-5-nano
+   azd env set AZURE_OPENAI_CHATGPT_DEPLOYMENT_VERSION 2025-08-07
+   azd env set AZURE_OPENAI_CHATGPT_DEPLOYMENT_SKU GlobalStandard
+   azd env set AZURE_OPENAI_API_VERSION 2025-04-01-preview
+   ```
 
    For o4-mini:
 
@@ -63,12 +96,12 @@ This repository includes an optional feature that uses reasoning models to gener
 
 2. **(Optional) Set default reasoning effort**
 
-   You can configure how much effort the reasoning model spends on processing and understanding the user's request. Valid options are `low`, `medium`, and `high`. Reasoning effort defaults to `medium` if not set.
+   You can configure how much effort the reasoning model spends on processing and understanding the user's request. Valid options are `minimal` (for GPT-5 models only), `low`, `medium`, and `high`. Reasoning effort defaults to `medium` if not set.
 
-   Set the environment variable for reasoning effort
+   Set the environment variable for reasoning effort:
 
    ```shell
-   azd env set AZURE_OPENAI_REASONING_EFFORT medium
+   azd env set AZURE_OPENAI_REASONING_EFFORT minimal
    ```
 
 3. **Update the infrastructure and application:**


### PR DESCRIPTION
## Purpose

This PR adds support for the new GPT-5 model family, adding -chat to the normal list in the docs, and the other ones to the reasoning docs/code. I do not yet have access to gpt-5 proper so couldnt do a full test with that, but gpt-5-mini and gpt-5-nano work as expected.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
