### PR TITLE
Update error message to be platform agnostic

### DIFF
--- a/app/backend/error.py
+++ b/app/backend/error.py
@@ -4,7 +4,7 @@ from openai import APIError
 from quart import jsonify
 
 ERROR_MESSAGE = """The app encountered an error processing your request.
-If you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.
+If you are an administrator of the app, check the application logs for a full traceback.
 Error type: {error_type}
 """
 ERROR_MESSAGE_FILTER = """Your message contains content that was flagged by the OpenAI content filter."""

--- a/tests/snapshots/test_app/test_ask_handle_exception/client0/result.json
+++ b/tests/snapshots/test_app/test_ask_handle_exception/client0/result.json
@@ -1,3 +1,3 @@
 {
-    "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.\nError type: <class 'ZeroDivisionError'>\n"
+    "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, check the application logs for a full traceback.\nError type: <class 'ZeroDivisionError'>\n"
 }

--- a/tests/snapshots/test_app/test_ask_handle_exception/client1/result.json
+++ b/tests/snapshots/test_app/test_ask_handle_exception/client1/result.json
@@ -1,3 +1,3 @@
 {
-    "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.\nError type: <class 'ZeroDivisionError'>\n"
+    "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, check the application logs for a full traceback.\nError type: <class 'ZeroDivisionError'>\n"
 }

--- a/tests/snapshots/test_app/test_chat_handle_exception/client0/result.json
+++ b/tests/snapshots/test_app/test_chat_handle_exception/client0/result.json
@@ -1,3 +1,3 @@
 {
-    "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.\nError type: <class 'ZeroDivisionError'>\n"
+    "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, check the application logs for a full traceback.\nError type: <class 'ZeroDivisionError'>\n"
 }

--- a/tests/snapshots/test_app/test_chat_handle_exception/client1/result.json
+++ b/tests/snapshots/test_app/test_chat_handle_exception/client1/result.json
@@ -1,3 +1,3 @@
 {
-    "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.\nError type: <class 'ZeroDivisionError'>\n"
+    "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, check the application logs for a full traceback.\nError type: <class 'ZeroDivisionError'>\n"
 }

--- a/tests/snapshots/test_app/test_chat_handle_exception_streaming/client0/result.jsonlines
+++ b/tests/snapshots/test_app/test_chat_handle_exception_streaming/client0/result.jsonlines
@@ -1,1 +1,1 @@
-{"error": "The app encountered an error processing your request.\nIf you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.\nError type: <class 'ZeroDivisionError'>\n"}
+{"error": "The app encountered an error processing your request.\nIf you are an administrator of the app, check the application logs for a full traceback.\nError type: <class 'ZeroDivisionError'>\n"}

--- a/tests/snapshots/test_app/test_chat_handle_exception_streaming/client1/result.jsonlines
+++ b/tests/snapshots/test_app/test_chat_handle_exception_streaming/client1/result.jsonlines
@@ -1,1 +1,1 @@
-{"error": "The app encountered an error processing your request.\nIf you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.\nError type: <class 'ZeroDivisionError'>\n"}
+{"error": "The app encountered an error processing your request.\nIf you are an administrator of the app, check the application logs for a full traceback.\nError type: <class 'ZeroDivisionError'>\n"}

--- a/tests/snapshots/test_app/test_chat_stream_handle_exception/client0/result.json
+++ b/tests/snapshots/test_app/test_chat_stream_handle_exception/client0/result.json
@@ -1,3 +1,3 @@
 {
-    "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.\nError type: <class 'ZeroDivisionError'>\n"
+    "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, check the application logs for a full traceback.\nError type: <class 'ZeroDivisionError'>\n"
 }

--- a/tests/snapshots/test_app/test_chat_stream_handle_exception/client1/result.json
+++ b/tests/snapshots/test_app/test_chat_stream_handle_exception/client1/result.json
@@ -1,3 +1,3 @@
 {
-    "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.\nError type: <class 'ZeroDivisionError'>\n"
+    "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, check the application logs for a full traceback.\nError type: <class 'ZeroDivisionError'>\n"
 }

--- a/tests/test_cosmosdb.py
+++ b/tests/test_cosmosdb.py
@@ -190,7 +190,7 @@ async def test_chathistory_newitem_error_runtime(auth_public_documents_client, m
     )
     assert response.status_code == 500
     assert (await response.get_json()) == {
-        "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.\nError type: <class 'IndexError'>\n"
+        "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, check the application logs for a full traceback.\nError type: <class 'IndexError'>\n"
     }
 
 
@@ -261,7 +261,7 @@ async def test_chathistory_query_error_runtime(auth_public_documents_client, mon
     )
     assert response.status_code == 500
     assert (await response.get_json()) == {
-        "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, view the full error in the logs. See aka.ms/appservice-logs for more information.\nError type: <class 'Exception'>\n"
+        "error": "The app encountered an error processing your request.\nIf you are an administrator of the app, check the application logs for a full traceback.\nError type: <class 'Exception'>\n"
     }
 
 


### PR DESCRIPTION
## Purpose

Fixes #2678

This pull request updates the error message shown when the app encounters an exception. The new message directs you to check the application logs for a full traceback, replacing the previous reference to aka.ms/appservice-logs. This is a better experience since developers may see the message locally, on Container Apps (the new default), or App Service (the old default). In the future, we could add a page that was specific about how to find logs across all three environments, but such a page doesn't exist yet, so better to remove the outdated link for now.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [X] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
