### PR TITLE
Hyperlink leads to random Korean betting website

### DIFF
--- a/docs/http_protocol.md
+++ b/docs/http_protocol.md
@@ -86,7 +86,7 @@ Example of the overrides object:
 
 ## HTTP responses from RAG chat app endpoints
 
-The HTTP response is JSON for a non-streaming response, or [newline-delimited JSON](https://ndjson.org/home/) ("NDJSON"/"jsonlines") for a streaming response.
+The HTTP response is JSON for a non-streaming response, or [newline-delimited JSON](https://database.guide/what-is-ndjson/) ("NDJSON"/"jsonlines") for a streaming response.
 
 ### Non-streaming response
 


### PR DESCRIPTION
## Purpose

Changed the hyperlink for ndjson to something that makes more sense or to at least bring awareness. The current hyperlink leads to a Korean betting website (https://ndjson.org/).

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X ] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X ] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
