### PR TITLE
Fix issue with BICEP, deployment template validation error

### DIFF
--- a/infra/private-endpoints.bicep
+++ b/infra/private-endpoints.bicep
@@ -52,8 +52,9 @@ var privateEndpointInfo = [
     resourceId: resourceId
   })
 ]
-module privateEndpoints './core/networking/private-endpoint.bicep' = [for privateEndpointInfo in flatten(privateEndpointInfo): {
-  name: '${privateEndpointInfo.name}-privateendpoint'
+
+module privateEndpoints './core/networking/private-endpoint.bicep' = [for (privateEndpointInfo, i) in flatten(privateEndpointInfo): {
+  name: '${privateEndpointInfo.name}-${i}-privateendpoint'
   params: {
     location: location
     name: '${privateEndpointInfo.name}${abbrs.privateEndpoint}${resourceToken}'
@@ -82,6 +83,7 @@ module monitorDnsZones './core/networking/private-dns-zones.bicep' = [for monito
     virtualNetworkName: vnetName
   }
 }]
+
 // Get blob DNS zone index for monitor private link
 var blobEndpointInfo = filter(flatten(privateEndpointInfo), info => info.groupId == 'blob')
 // Assert that blob endpoints exist (required for this application)


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
**When deploying using "PRIVATE NETWORK", the Azure Bicep file was error'ing when applying.
Specifically - the NAME of each private network, needed to include ${i} - to ensure uniqueness.**



## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[ X ] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[ X ] No
```

## Type of change

```
[ X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
