### PR TITLE
Add dependabot group for pydantic

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -27,3 +27,7 @@ updates:
         patterns:
           - "opentelemetry-*"
           - "azure-monitor-opentelemetry*"
+      pydantic:
+        patterns:
+          - "pydantic"
+          - "pydantic-*"


### PR DESCRIPTION
## Purpose

This pull request adds support for managing updates to `pydantic` dependencies in the Dependabot configuration, as we've had dependabot PRs failing that try to update one pydantic package at a time. This ensures that both `pydantic` and any related packages prefixed with `pydantic-` (pydantic-core currently) will be automatically checked for updates.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

N/A