### PR TITLE
do not add local path to file as url

### DIFF
--- a/app/backend/prepdocslib/listfilestrategy.py
+++ b/app/backend/prepdocslib/listfilestrategy.py
@@ -111,7 +111,7 @@ class LocalListFileStrategy(ListFileStrategy):
         acls = {"oids": ["all"], "groups": ["all"]} if self.enable_global_documents else {}
         async for path in self.list_paths():
             if not self.check_md5(path):
-                yield File(content=open(path, mode="rb"), acls=acls, url=path)
+                yield File(content=open(path, mode="rb"), acls=acls)
 
     def check_md5(self, path: str) -> bool:
         # if filename ends in .md5 skip


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Listfile strategy adds the local filepath to the URL field of listfilestrategy.File. This causes all file uploads to blob storage to be skipped, which breaks the file viewer feature of the citation.

Simply leaving the field empty fixes the issue for me - I am unaware of any side-effects of this simple fix. But I am also not deeply familiar with all aspects of this project.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[ x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[ x] No
```

## Type of change

```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ x] The current tests all pass (`python -m pytest`).
- [ does not apply] I added tests that prove my fix is effective or that my feature works 
- [ x] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ x] I ran `python -m mypy` to check for type errors
- [ x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
