### PR TITLE
Comment out the functions by default

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -41,26 +41,26 @@ services:
           interactive: false
           continueOnError: false
   # Un-comment this section if using USE_CLOUD_INGESTION option
-  document-extractor:
-    project: ./app/functions/document_extractor
-    language: py
-    host: function
-    hooks:
-      prepackage:
-        shell: pwsh
-        run: python ../../../scripts/copy_prepdocslib.py
-        interactive: false
-        continueOnError: false
-  figure-processor:
-    project: ./app/functions/figure_processor
-    language: py
-    host: function
-    hooks:
-      prepackage:
-        shell: pwsh
-        run: python ../../../scripts/copy_prepdocslib.py
-        interactive: false
-        continueOnError: false
+  # document-extractor:
+  #   project: ./app/functions/document_extractor
+  #   language: py
+  #   host: function
+  #   hooks:
+  #     prepackage:
+  #       shell: pwsh
+  #       run: python ../../../scripts/copy_prepdocslib.py
+  #       interactive: false
+  #       continueOnError: false
+  # figure-processor:
+  #   project: ./app/functions/figure_processor
+  #   language: py
+  #   host: function
+  #   hooks:
+  #     prepackage:
+  #       shell: pwsh
+  #       run: python ../../../scripts/copy_prepdocslib.py
+  #       interactive: false
+  #       continueOnError: false
   text-processor:
     project: ./app/functions/text_processor
     language: py


### PR DESCRIPTION
## Purpose

I accidentally checked in the un-commented azure.yaml, but the functions need to be commented out by default.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

N/A