### PR TITLE
Remove snippet from WebResult since the web source does not provide it

### DIFF
--- a/app/backend/approaches/approach.py
+++ b/app/backend/approaches/approach.py
@@ -109,7 +109,6 @@ class WebResult:
     id: Optional[str] = None
     title: Optional[str] = None
     url: Optional[str] = None
-    snippet: Optional[str] = None
     activity: Optional[ActivityDetail] = None
 
     def serialize_for_results(self) -> dict[str, Any]:
@@ -119,7 +118,6 @@ class WebResult:
             "ref_id": str(self.id),
             "title": self.title,
             "url": self.url,
-            "snippet": self.snippet,
             "activity": asdict(self.activity) if self.activity else None,
         }
 
@@ -797,7 +795,6 @@ class Approach(ABC):
                         "id": web.id,
                         "title": web.title,
                         "url": web.url,
-                        "snippet": clean_source(web.snippet or ""),
                         "activity": asdict(web.activity) if web.activity else None,
                     }
                 )

--- a/app/frontend/src/components/SupportingContent/SupportingContent.tsx
+++ b/app/frontend/src/components/SupportingContent/SupportingContent.tsx
@@ -42,7 +42,6 @@ export const SupportingContent = ({ supportingContent }: Props) => {
                     ) : (
                         <h4 className={styles.supportingContentItemHeader}>{item.title ?? "Web result"}</h4>
                     )}
-                    {item.snippet && <p className={styles.supportingContentItemText} dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(item.snippet) }} />}
                 </li>
             ))}
         </ul>

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -491,13 +491,7 @@ def mock_retrieval_response_with_web():
                     "sourcefile": "Benefit_Options.pdf",
                 },
             ),
-            KnowledgeBaseWebReference(
-                id=1,
-                activity_source=2,
-                url="https://contoso.example",
-                title="Contoso site",
-                snippet="Contoso policy overview",
-            ),
+            KnowledgeBaseWebReference(id=1, activity_source=2, url="https://contoso.example", title="Contoso site"),
         ],
     )
 

--- a/tests/snapshots/test_app/test_ask_rtr_text_agent/knowledgebase_client1_web/result.json
+++ b/tests/snapshots/test_app/test_ask_rtr_text_agent/knowledgebase_client1_web/result.json
@@ -31,7 +31,6 @@
                         "type": "web"
                     },
                     "id": 1,
-                    "snippet": "",
                     "title": "Contoso site",
                     "url": "https://contoso.example"
                 }
@@ -75,7 +74,6 @@
                         },
                         "id": 1,
                         "ref_id": "1",
-                        "snippet": null,
                         "title": "Contoso site",
                         "type": "web",
                         "url": "https://contoso.example"

--- a/tests/snapshots/test_app/test_chat_text_agent/knowledgebase_client1_web/result.json
+++ b/tests/snapshots/test_app/test_chat_text_agent/knowledgebase_client1_web/result.json
@@ -31,7 +31,6 @@
                         "type": "web"
                     },
                     "id": 1,
-                    "snippet": "",
                     "title": "Contoso site",
                     "url": "https://contoso.example"
                 }
@@ -76,7 +75,6 @@
                         },
                         "id": 1,
                         "ref_id": "1",
-                        "snippet": null,
                         "title": "Contoso site",
                         "type": "web",
                         "url": "https://contoso.example"


### PR DESCRIPTION
## Purpose

The web knowledge source does not provide snippets (for licensing reasons), but our code mistakenly made it seem like web results might have snippet. This PR fixes that by removing snippet from WebResult backend and frontend.

Fixes #2838 


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [x] I added tests that prove my fix is effective or that my feature works
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
