### PR TITLE
Remove description from web knowledge source

### DIFF
--- a/app/backend/prepdocslib/searchmanager.py
+++ b/app/backend/prepdocslib/searchmanager.py
@@ -513,8 +513,8 @@ class SearchManager:
                 if self.use_web_source:
                     logger.info("Adding web knowledge source to the knowledge base")
                     web_knowledge_source = WebKnowledgeSource(
-                        name="web",
-                        description="Default web knowledge source",
+                        name="web"
+                        # We do not specify a description here, since the default description is quite detailed already
                     )
                     await search_index_client.create_or_update_knowledge_source(knowledge_source=web_knowledge_source)
                     knowledge_source_refs["web"] = KnowledgeSourceReference(name=web_knowledge_source.name)


### PR DESCRIPTION
## Purpose

We discussed at Ignite that it's generally better to defer to the built-in description.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [x] I added tests that prove my fix is effective or that my feature works
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
