### PR TITLE
Allow for EML and MSG parsing / also check+replace if fileName has "#" character

### DIFF
--- a/app/backend/package-lock.json
+++ b/app/backend/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "backend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/app/backend/prepdocslib/cloudingestionstrategy.py
+++ b/app/backend/prepdocslib/cloudingestionstrategy.py
@@ -1,6 +1,7 @@
 """Cloud ingestion strategy using Azure AI Search custom skills."""
 
 import logging
+import os
 from dataclasses import dataclass
 from datetime import timedelta
 
@@ -319,6 +320,28 @@ class CloudIngestionStrategy(Strategy):  # pragma: no cover
         files = self.list_file_strategy.list()
         async for file in files:
             try:
+                # Check if filename contains # and rename on disk if it does
+                if hasattr(file.content, "name") and "#" in file.filename():
+                    original_path = file.content.name
+                    if os.path.exists(original_path) and os.path.isfile(original_path):
+                        # Get directory and filename
+                        directory = os.path.dirname(original_path)
+                        original_filename = os.path.basename(original_path)
+                        new_filename = original_filename.replace("#", "_")
+                        new_path = os.path.join(directory, new_filename)
+                        
+                        # Only rename if the new filename is different
+                        if new_path != original_path:
+                            # Close the current file handle
+                            file.content.close()
+                            
+                            # Rename the file on disk
+                            os.rename(original_path, new_path)
+                            logger.info("Renamed file from '%s' to '%s' (replaced # with _)", original_filename, new_filename)
+                            
+                            # Reopen the file with the new name
+                            file.content = open(new_path, mode="rb")
+                
                 await self.blob_manager.upload_blob(file)
             finally:
                 if file:

--- a/app/backend/prepdocslib/emailparser.py
+++ b/app/backend/prepdocslib/emailparser.py
@@ -1,0 +1,137 @@
+"""
+Email parser for MSG and EML files.
+Compatible with the prepdocs pipeline structure.
+"""
+import logging
+import email
+from email import policy
+from typing import AsyncGenerator, IO, Union, Optional
+import extract_msg
+from io import BytesIO
+import re
+
+from .page import Page
+
+logger = logging.getLogger(__name__)
+
+
+class EmailParser:
+    """Parser for EML email files."""
+    
+    async def parse(self, content: IO) -> AsyncGenerator[Page, None]:
+        """Parse EML file content."""
+        try:
+            # Read bytes from IO object
+            content_bytes = content.read()
+            # Parse email from bytes
+            msg = email.message_from_bytes(content_bytes, policy=policy.default)
+            
+            # Extract email metadata and body
+            text_parts = []
+            
+            # Add headers
+            text_parts.append(f"From: {msg.get('From', 'Unknown')}")
+            text_parts.append(f"To: {msg.get('To', 'Unknown')}")
+            text_parts.append(f"Subject: {msg.get('Subject', 'No Subject')}")
+            text_parts.append(f"Date: {msg.get('Date', 'Unknown')}")
+            text_parts.append("\n" + "="*80 + "\n")
+            
+            # Extract body
+            if msg.is_multipart():
+                for part in msg.walk():
+                    content_type = part.get_content_type()
+                    content_disposition = str(part.get("Content-Disposition", ""))
+                    
+                    # Get text content
+                    if content_type == "text/plain" and "attachment" not in content_disposition:
+                        try:
+                            body = part.get_content()
+                            text_parts.append(body)
+                        except Exception as e:
+                            logger.warning(f"Could not extract text part: {e}")
+                    
+                    elif content_type == "text/html" and "attachment" not in content_disposition:
+                        # Optionally extract HTML (you may want to strip HTML tags)
+                        try:
+                            html_body = part.get_content()
+                            # Simple HTML tag removal (consider using BeautifulSoup for better results)
+                            import re
+                            text_body = re.sub('<[^<]+?>', '', html_body)
+                            text_parts.append(text_body)
+                        except Exception as e:
+                            logger.warning(f"Could not extract HTML part: {e}")
+                    
+                    # Note attachments
+                    elif "attachment" in content_disposition:
+                        filename = part.get_filename()
+                        if filename:
+                            text_parts.append(f"\n[Attachment: {filename}]")
+            else:
+                # Single part message
+                try:
+                    body = msg.get_content()
+                    text_parts.append(body)
+                except Exception as e:
+                    logger.warning(f"Could not extract message body: {e}")
+            
+            # Combine all parts
+            full_text = "\n".join(text_parts)
+            
+            # Return as single page
+            yield Page(page_num=0, offset=0, text=full_text)
+            
+        except Exception as e:
+            logger.error(f"Error parsing EML file: {e}")
+            raise ValueError(f"Failed to parse EML file: {e}")
+
+
+class MsgParser:
+    """Parser for MSG (Outlook) email files."""
+    
+    async def parse(self, content: IO) -> AsyncGenerator[Page, None]:
+        """Parse MSG file content."""
+        try:
+            # Read bytes from IO object and create BytesIO
+            content_bytes = content.read()
+            msg_file = BytesIO(content_bytes)
+            
+            # Parse MSG file
+            msg = extract_msg.Message(msg_file)
+            
+            # Extract email metadata and body
+            text_parts = []
+            
+            # Add headers
+            text_parts.append(f"From: {msg.sender or 'Unknown'}")
+            text_parts.append(f"To: {msg.to or 'Unknown'}")
+            text_parts.append(f"Subject: {msg.subject or 'No Subject'}")
+            text_parts.append(f"Date: {msg.date or 'Unknown'}")
+            text_parts.append("\n" + "="*80 + "\n")
+            
+            # Add body (prefer plain text over HTML)
+            if msg.body:
+                text_parts.append(msg.body)
+            elif msg.htmlBody:
+                # Simple HTML tag removal
+                import re
+                text_body = re.sub('<[^<]+?>', '', msg.htmlBody)
+                text_parts.append(text_body)
+            
+            # Note attachments
+            if msg.attachments:
+                text_parts.append("\n\nAttachments:")
+                for attachment in msg.attachments:
+                    text_parts.append(f"  - {attachment.longFilename or attachment.shortFilename}")
+            
+            # Combine all parts
+            full_text = "\n".join(text_parts)
+            
+            # Clean up
+            msg.close()
+            
+            # Return as single page
+            yield Page(page_num=0, offset=0, text=full_text)
+            
+        except Exception as e:
+            logger.error(f"Error parsing MSG file: {e}")
+            raise ValueError(f"Failed to parse MSG file: {e}")

--- a/app/backend/prepdocslib/servicesetup.py
+++ b/app/backend/prepdocslib/servicesetup.py
@@ -23,6 +23,8 @@ from .pdfparser import DocumentAnalysisParser, LocalPdfParser
 from .strategy import SearchInfo
 from .textparser import TextParser
 from .textsplitter import SentenceTextSplitter, SimpleTextSplitter
+from .emailparser import EmailParser
+from .emailparser import MsgParser
 
 logger = logging.getLogger("scripts")
 
@@ -290,6 +292,8 @@ def build_file_processors(
         ".md": FileProcessor(TextParser(), sentence_text_splitter),
         ".txt": FileProcessor(TextParser(), sentence_text_splitter),
         ".csv": FileProcessor(CsvParser(), sentence_text_splitter),
+        ".eml": FileProcessor(EmailParser(), sentence_text_splitter),
+        ".msg": FileProcessor(MsgParser(), sentence_text_splitter),
     }
     # These require either a Python package or Document Intelligence
     if pdf_parser is not None:

--- a/app/backend/requirements.in
+++ b/app/backend/requirements.in
@@ -31,3 +31,4 @@ python-dotenv
 prompty
 rich
 typing-extensions
+extract-msg

--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -454,3 +454,5 @@ yarl==1.17.2
     # via aiohttp
 zipp==3.21.0
     # via importlib-metadata
+extract-msg==0.42.1
+    # via -r requirements.in

--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -13,13 +13,16 @@
         "@fluentui/react": "^8.112.5",
         "@fluentui/react-components": "^9.56.2",
         "@fluentui/react-icons": "^2.0.265",
+        "@kenjiuno/msgreader": "^1.27.0-alpha.3",
         "@react-spring/web": "^9.7.5",
+        "buffer": "^6.0.3",
         "dompurify": "^3.2.4",
         "i18next": "^24.2.0",
         "i18next-browser-languagedetector": "^8.0.2",
         "i18next-http-backend": "^3.0.1",
         "idb": "^8.0.0",
         "ndjson-readablestream": "^1.2.0",
+        "postal-mime": "^2.6.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-helmet-async": "^2.0.5",
@@ -2509,6 +2512,25 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kenjiuno/decompressrtf": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@kenjiuno/decompressrtf/-/decompressrtf-0.1.4.tgz",
+      "integrity": "sha512-v9c/iFz17jRWyd2cRnrvJg4VOg/4I/VCk+bG8JnoX2gJ9sAesPzo3uTqcmlVXdpasTI8hChpBVw00pghKe3qTQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@kenjiuno/msgreader": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@kenjiuno/msgreader/-/msgreader-1.27.0.tgz",
+      "integrity": "sha512-gElRDjxQGZQBVAqQYfZ4g82DqBQQubg9pg+nz6DsWG7tTx0TozNqaglGovT6tz3vqNE07u/wu88w8ymU1BIxYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@kenjiuno/decompressrtf": "^0.1.3",
+        "iconv-lite": "^0.6.3"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@microsoft/load-themed-styles": {
       "version": "1.10.295",
       "license": "MIT"
@@ -3080,6 +3102,26 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/browserslist": {
       "version": "4.25.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
@@ -3111,6 +3153,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -3761,10 +3827,42 @@
         "cross-fetch": "4.0.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/idb": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.0.tgz",
       "integrity": "sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw=="
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.3",
@@ -4958,6 +5056,12 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.6.1.tgz",
+      "integrity": "sha512-YnNYvLTsWzk1Mpf1drc7XZPR1c2XInI94H5RY/hZ9vzTSYjLw9zuebdi/K0yfR3PVnedQZUn2umTyxfw9yOWBA==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -5398,6 +5502,12 @@
       "dependencies": {
         "@babel/runtime": "^7.1.2"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.20.2",

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -17,6 +17,7 @@
     "@fluentui/react": "^8.112.5",
     "@fluentui/react-components": "^9.56.2",
     "@fluentui/react-icons": "^2.0.265",
+    "@kenjiuno/msgreader": "^1.27.0-alpha.3",
     "@react-spring/web": "^9.7.5",
     "dompurify": "^3.2.4",
     "i18next": "^24.2.0",
@@ -24,6 +25,7 @@
     "i18next-http-backend": "^3.0.1",
     "idb": "^8.0.0",
     "ndjson-readablestream": "^1.2.0",
+    "postal-mime": "^2.6.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet-async": "^2.0.5",
@@ -33,7 +35,8 @@
     "react-syntax-highlighter": "^16.1.0",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.0",
-    "scheduler": "^0.20.2"
+    "scheduler": "^0.20.2",
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@types/dom-speech-recognition": "^0.0.7",

--- a/app/frontend/src/components/AnalysisPanel/AnalysisPanel.module.css
+++ b/app/frontend/src/components/AnalysisPanel/AnalysisPanel.module.css
@@ -82,6 +82,13 @@
     object-fit: contain;
 }
 
+.citationContainer {
+    width: 100%;
+    overflow-x: hidden;
+    overflow-y: auto;
+    box-sizing: border-box;
+}
+
 .header {
     color: #123bb6;
     position: relative;

--- a/app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsx
+++ b/app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { ChatAppResponse, getHeaders } from "../../api";
 import { getToken, useLogin } from "../../authConfig";
 import { MarkdownViewer } from "../MarkdownViewer";
+import { EmailViewer } from "../EmailViewer";
 import { SupportingContent } from "../SupportingContent";
 import styles from "./AnalysisPanel.module.css";
 import { AnalysisPanelTabs } from "./AnalysisPanelTabs";
@@ -44,7 +45,8 @@ export const AnalysisPanel = ({ answer, activeTab, activeCitation, citationHeigh
         if (activeCitation) {
             // Get hash from the URL as it may contain #page=N
             // which helps browser PDF renderer jump to correct page N
-            const originalHash = activeCitation.indexOf("#") ? activeCitation.split("#")[1] : "";
+            const hashIndex = activeCitation.indexOf("#");
+            const originalHash = hashIndex >= 0 ? activeCitation.split("#")[1] : "";
             const response = await fetch(activeCitation, {
                 method: "GET",
                 headers: await getHeaders(token)
@@ -73,6 +75,9 @@ export const AnalysisPanel = ({ answer, activeTab, activeCitation, citationHeigh
                 return <img src={citation} className={styles.citationImg} alt="Citation Image" />;
             case "md":
                 return <MarkdownViewer src={activeCitation} />;
+            case "eml":
+            case "msg":
+                return <EmailViewer src={activeCitation} height={citationHeight} />;
             default:
                 return <iframe title="Citation" src={citation} width="100%" height={citationHeight} />;
         }
@@ -103,7 +108,9 @@ export const AnalysisPanel = ({ answer, activeTab, activeCitation, citationHeigh
                 headerText={t("headerTexts.citation")}
                 headerButtonProps={isDisabledCitationTab ? pivotItemDisabledStyle : undefined}
             >
-                {renderFileViewer()}
+                <div className={styles.citationContainer}>
+                    {renderFileViewer()}
+                </div>
             </PivotItem>
         </Pivot>
     );

--- a/app/frontend/src/components/EmailViewer/EmailViewer.module.css
+++ b/app/frontend/src/components/EmailViewer/EmailViewer.module.css
@@ -1,0 +1,50 @@
+.emailViewer {
+    padding: 20px;
+    min-height: 400px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.error {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.emailContainer {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+
+.emailFrame {
+    width: 100%;
+    height: 100%;
+    border: none;
+    background-color: white;
+    overflow-x: hidden;
+}
+
+.downloadButton {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 10;
+    background-color: rgba(255, 255, 255, 0.9);
+    border-radius: 4px;
+}
+
+.downloadButton:hover {
+    background-color: rgba(240, 240, 240, 0.95);
+}
+

--- a/app/frontend/src/components/EmailViewer/EmailViewer.tsx
+++ b/app/frontend/src/components/EmailViewer/EmailViewer.tsx
@@ -1,0 +1,309 @@
+import { Spinner, SpinnerSize, MessageBar, MessageBarType, Link, IconButton } from "@fluentui/react";
+import { useTranslation } from "react-i18next";
+import React, { useState, useEffect } from "react";
+// @ts-ignore - postal-mime doesn't have type definitions
+import PostalMime from "postal-mime";
+import MsgReader from "@kenjiuno/msgreader";
+import { useMsal } from "@azure/msal-react";
+import { getHeaders } from "../../api";
+import { useLogin, getToken } from "../../authConfig";
+
+import styles from "./EmailViewer.module.css";
+
+interface EmailViewerProps {
+    src: string;
+    height?: string;
+}
+
+interface ParsedEmail {
+    subject?: string;
+    from?: { name?: string; address?: string };
+    to?: Array<{ name?: string; address?: string }>;
+    cc?: Array<{ name?: string; address?: string }>;
+    date?: string;
+    html?: string;
+    text?: string;
+    attachments?: Array<{ filename?: string; size?: number }>;
+}
+
+export const EmailViewer: React.FC<EmailViewerProps> = ({ src, height }) => {
+    const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [error, setError] = useState<Error | null>(null);
+    const [emailHtml, setEmailHtml] = useState<string>("");
+    const { t } = useTranslation();
+    const client = useLogin ? useMsal().instance : undefined;
+
+    // Helper function to escape HTML
+    const escapeHtml = (text: string): string => {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    };
+
+    // Helper function to format bytes
+    const formatBytes = (bytes: number): string => {
+        if (bytes === 0) return '0 Bytes';
+        const k = 1024;
+        const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+        const i = Math.floor(Math.log(bytes) / Math.log(k));
+        return Math.round(bytes / Math.pow(k, i) * 100) / 100 + ' ' + sizes[i];
+    };
+
+    // Parse MSG file
+    const parseMsgFile = async (arrayBuffer: ArrayBuffer): Promise<ParsedEmail> => {
+        try {
+            const msgReader = new MsgReader(arrayBuffer);
+            const fileData = msgReader.getFileData();
+            
+            console.log("MSG parsed successfully:", {
+                subject: fileData.subject,
+                senderName: fileData.senderName,
+                hasBody: !!fileData.body,
+                hasBodyHTML: !!fileData.bodyHtml
+            });
+
+            // Convert MSG recipients to standard format
+            const to = fileData.recipients?.map(r => ({
+                name: r.name || '',
+                address: r.email || ''
+            })) || [];
+
+            return {
+                subject: fileData.subject || '',
+                from: {
+                    name: fileData.senderName || '',
+                    address: fileData.senderEmail || ''
+                },
+                to: to,
+                cc: [], // MSG parser might not separate CC easily
+                date: fileData.creationTime || fileData.messageDeliveryTime || '',
+                html: fileData.bodyHtml || '',
+                text: fileData.body || '',
+                attachments: fileData.attachments?.map(att => {
+                    const attachment = att as any;
+                    return {
+                        filename: att.fileName || att.name || 'unnamed',
+                        size: attachment.content?.length || attachment.data?.length || attachment.size || 0
+                    };
+                }) || []
+            };
+        } catch (err) {
+            console.error("Error parsing MSG file:", err);
+            throw new Error(`Failed to parse MSG file: ${err instanceof Error ? err.message : 'Unknown error'}`);
+        }
+    };
+
+    // Parse EML file
+    const parseEmlFile = async (arrayBuffer: ArrayBuffer): Promise<ParsedEmail> => {
+        try {
+            const parser = new PostalMime();
+            const email = await parser.parse(arrayBuffer);
+            
+            console.log("EML parsed successfully:", {
+                subject: email.subject,
+                from: email.from,
+                hasHtml: !!email.html,
+                hasText: !!email.text
+            });
+
+            return email as ParsedEmail;
+        } catch (err) {
+            console.error("Error parsing EML file:", err);
+            throw new Error(`Failed to parse EML file: ${err instanceof Error ? err.message : 'Unknown error'}`);
+        }
+    };
+
+    // Generate HTML from parsed email
+    const generateEmailHtml = (email: ParsedEmail): string => {
+        return `
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta charset="UTF-8">
+                <style>
+                    body {
+                        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+                        padding: 20px;
+                        margin: 0;
+                        background-color: #ffffff;
+                        color: #333;
+                        line-height: 1.6;
+                        overflow-x: hidden;
+                        word-wrap: break-word;
+                        max-width: 100%;
+                    }
+                    .email-header {
+                        border-bottom: 2px solid #e0e0e0;
+                        padding-bottom: 15px;
+                        margin-bottom: 20px;
+                    }
+                    .email-field {
+                        margin: 8px 0;
+                    }
+                    .email-label {
+                        font-weight: 600;
+                        color: #666;
+                        display: inline-block;
+                        min-width: 80px;
+                    }
+                    .email-value {
+                        color: #333;
+                    }
+                    .email-subject {
+                        font-size: 1.3em;
+                        font-weight: 600;
+                        margin: 15px 0;
+                        color: #000;
+                    }
+                    .email-body {
+                        margin-top: 20px;
+                        padding: 15px;
+                        background-color: #fafafa;
+                        border-radius: 4px;
+                        overflow-x: hidden;
+                        word-wrap: break-word;
+                        max-width: 100%;
+                    }
+                    .attachment-list {
+                        margin-top: 20px;
+                        padding: 15px;
+                        background-color: #f5f5f5;
+                        border-left: 3px solid #0078d4;
+                    }
+                    .attachment-item {
+                        margin: 5px 0;
+                        color: #0078d4;
+                    }
+                </style>
+            </head>
+            <body>
+                <div class="email-header">
+                    ${email.subject ? `<div class="email-subject">${escapeHtml(email.subject)}</div>` : ''}
+                    ${email.from ? `<div class="email-field"><span class="email-label">From:</span> <span class="email-value">${email.from.name ? escapeHtml(email.from.name) : ''} ${email.from.address ? `&lt;${escapeHtml(email.from.address)}&gt;` : ''}</span></div>` : ''}
+                    ${email.to && email.to.length > 0 ? `<div class="email-field"><span class="email-label">To:</span> <span class="email-value">${email.to.map((addr: any) => {
+                        const name = addr.name ? escapeHtml(addr.name) : '';
+                        const address = addr.address ? `&lt;${escapeHtml(addr.address)}&gt;` : '';
+                        return `${name} ${address}`.trim();
+                    }).join(', ')}</span></div>` : ''}
+                    ${email.cc && email.cc.length > 0 ? `<div class="email-field"><span class="email-label">CC:</span> <span class="email-value">${email.cc.map((addr: any) => {
+                        const name = addr.name ? escapeHtml(addr.name) : '';
+                        const address = addr.address ? `&lt;${escapeHtml(addr.address)}&gt;` : '';
+                        return `${name} ${address}`.trim();
+                    }).join(', ')}</span></div>` : ''}
+                    ${email.date ? `<div class="email-field"><span class="email-label">Date:</span> <span class="email-value">${new Date(email.date).toLocaleString()}</span></div>` : ''}
+                </div>
+                <div class="email-body">
+                    ${email.html || (email.text ? `<pre style="white-space: pre-wrap; font-family: inherit;">${escapeHtml(email.text)}</pre>` : '<p><em>No content</em></p>')}
+                </div>
+                ${email.attachments && email.attachments.length > 0 ? `
+                    <div class="attachment-list">
+                        <strong>Attachments (${email.attachments.length}):</strong>
+                        ${email.attachments.map((att: any) => {
+                            const filename = att.filename || 'unnamed';
+                            return `<div class="attachment-item">📎 ${escapeHtml(filename)} (${formatBytes(att.size || 0)})</div>`;
+                        }).join('')}
+                    </div>
+                ` : ''}
+            </body>
+            </html>
+        `;
+    };
+
+    useEffect(() => {
+        const fetchAndParseEmail = async () => {
+            setIsLoading(true);
+            setError(null);
+
+            try {
+                const token = client ? await getToken(client) : undefined;
+                
+                // Detect file type
+                const isMsgFile = src.toLowerCase().endsWith('.msg');
+                const isEmlFile = src.toLowerCase().endsWith('.eml');
+                
+                console.log(`Fetching ${isMsgFile ? 'MSG' : isEmlFile ? 'EML' : 'email'} file from:`, src);
+                
+                const response = await fetch(src, {
+                    method: "GET",
+                    headers: await getHeaders(token)
+                });
+                
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch email: ${response.statusText}`);
+                }
+
+                const emailContent = await response.arrayBuffer();
+                console.log("Email content fetched, size:", emailContent.byteLength);
+                
+                let parsedEmail: ParsedEmail;
+
+                // Parse based on file type
+                if (isMsgFile) {
+                    console.log("Parsing as MSG file...");
+                    parsedEmail = await parseMsgFile(emailContent);
+                } else {
+                    console.log("Parsing as EML file...");
+                    parsedEmail = await parseEmlFile(emailContent);
+                }
+
+                // Generate HTML
+                const html = generateEmailHtml(parsedEmail);
+                console.log("Generated HTML length:", html.length);
+                
+                setEmailHtml(html);
+                setIsLoading(false);
+            } catch (err) {
+                console.error("Error loading email:", err);
+                setError(err instanceof Error ? err : new Error("Unknown error"));
+                setIsLoading(false);
+            }
+        };
+
+        if (src) {
+            fetchAndParseEmail();
+        }
+    }, [src, client]);
+
+    return (
+        <div>
+            {isLoading ? (
+                <div className={`${styles.loading} ${styles.emailViewer}`}>
+                    <Spinner size={SpinnerSize.large} label="Loading email..." />
+                </div>
+            ) : error ? (
+                <div className={`${styles.error} ${styles.emailViewer}`}>
+                    <MessageBar messageBarType={MessageBarType.error} isMultiline={false}>
+                        {error.message}
+                        <Link href={src} download>
+                            Download the file
+                        </Link>
+                    </MessageBar>
+                </div>
+            ) : emailHtml ? (
+                <div className={styles.emailContainer} style={height ? { height } : undefined}>
+                    <IconButton
+                        className={styles.downloadButton}
+                        style={{ color: "black" }}
+                        iconProps={{ iconName: "Save" }}
+                        title={t("tooltips.save")}
+                        ariaLabel={t("tooltips.save")}
+                        href={src}
+                        download
+                    />
+                    <iframe 
+                        title="Email Viewer"
+                        className={styles.emailFrame}
+                        srcDoc={emailHtml}
+                        sandbox="allow-same-origin"
+                    />
+                </div>
+            ) : (
+                <div className={`${styles.error} ${styles.emailViewer}`}>
+                    <MessageBar messageBarType={MessageBarType.warning} isMultiline={false}>
+                        No email content to display
+                    </MessageBar>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/app/frontend/src/components/EmailViewer/index.ts
+++ b/app/frontend/src/components/EmailViewer/index.ts
@@ -1,0 +1,2 @@
+export { EmailViewer } from "./EmailViewer";
+

--- a/app/frontend/src/index.tsx
+++ b/app/frontend/src/index.tsx
@@ -6,6 +6,13 @@ import { HelmetProvider } from "react-helmet-async";
 import { initializeIcons } from "@fluentui/react";
 import { MsalProvider } from "@azure/msal-react";
 import { AuthenticationResult, EventType, PublicClientApplication } from "@azure/msal-browser";
+import { Buffer } from "buffer";
+
+// Polyfill Buffer for browser environment
+if (typeof window !== "undefined" && !window.Buffer) {
+    window.Buffer = Buffer;
+    (globalThis as any).Buffer = Buffer;
+}
 
 import "./index.css";
 

--- a/app/frontend/src/pages/ask/Ask.module.css
+++ b/app/frontend/src/pages/ask/Ask.module.css
@@ -63,6 +63,7 @@
     padding-left: 9rem;
     padding-right: 1rem;
     align-self: flex-end;
+    min-height: 60px;
 }
 
 .commandButton {
@@ -72,12 +73,13 @@
 @media (min-width: 992px) {
     .askTitle {
         font-size: 4rem;
-        margin-top: 8.125rem;
+        margin-top: 0;
     }
 
     .commandsContainer {
         padding-left: 0;
         padding-right: 0;
+        min-height: 60px;
     }
 
     .commandButton {

--- a/app/frontend/src/pages/chat/Chat.module.css
+++ b/app/frontend/src/pages/chat/Chat.module.css
@@ -26,7 +26,6 @@
     justify-content: center;
     align-items: center;
     max-height: 64rem;
-    padding-top: 1rem;
 }
 
 .chatEmptyStateTitle {

--- a/app/frontend/src/vite-env.d.ts
+++ b/app/frontend/src/vite-env.d.ts
@@ -1,1 +1,12 @@
 /// <reference types="vite/client" />
+
+import type { Buffer } from "buffer";
+
+// Extend Window interface to include Buffer polyfill
+declare global {
+    interface Window {
+        Buffer: typeof Buffer;
+    }
+}
+
+export {};

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -5,7 +5,21 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
     plugins: [react()],
     resolve: {
-        preserveSymlinks: true
+        preserveSymlinks: true,
+        alias: {
+            buffer: "buffer",
+        },
+    },
+    define: {
+        global: "globalThis",
+        "process.env": {},
+    },
+    optimizeDeps: {
+        esbuildOptions: {
+            define: {
+                global: "globalThis",
+            },
+        },
     },
     build: {
         outDir: "../backend/static",
@@ -24,7 +38,10 @@ export default defineConfig({
                 }
             }
         },
-        target: "esnext"
+        target: "esnext",
+        commonjsOptions: {
+            transformMixedEsModules: true,
+        },
     },
     server: {
         proxy: {

--- a/scripts/auth_update.ps1
+++ b/scripts/auth_update.ps1
@@ -11,4 +11,8 @@ if (Test-Path -Path "/usr") {
   $venvPythonPath = "./.venv/bin/python"
 }
 
-Start-Process -FilePath $venvPythonPath -ArgumentList "./scripts/auth_update.py" -Wait -NoNewWindow
+$process = Start-Process -FilePath $venvPythonPath -ArgumentList "./scripts/auth_update.py" -Wait -NoNewWindow -PassThru
+if ($process.ExitCode -ne 0) {
+    Write-Error "auth_update.py failed with exit code $($process.ExitCode)"
+    exit $process.ExitCode
+}

--- a/scripts/load_python_env.ps1
+++ b/scripts/load_python_env.ps1
@@ -4,8 +4,17 @@ if (-not $pythonCmd) {
   $pythonCmd = Get-Command python3 -ErrorAction SilentlyContinue
 }
 
+if (-not $pythonCmd) {
+    Write-Error "Python not found. Please install Python and ensure it's in your PATH."
+    exit 1
+}
+
 Write-Host 'Creating python virtual environment ".venv"'
-Start-Process -FilePath ($pythonCmd).Source -ArgumentList "-m venv ./.venv" -Wait -NoNewWindow
+$process = Start-Process -FilePath ($pythonCmd).Source -ArgumentList "-m venv ./.venv" -Wait -NoNewWindow -PassThru
+if ($process.ExitCode -ne 0) {
+    Write-Error "Failed to create virtual environment with exit code $($process.ExitCode)"
+    exit $process.ExitCode
+}
 
 $venvPythonPath = "./.venv/scripts/python.exe"
 if (Test-Path -Path "/usr") {
@@ -14,4 +23,8 @@ if (Test-Path -Path "/usr") {
 }
 
 Write-Host 'Installing dependencies from "requirements.txt" into virtual environment'
-Start-Process -FilePath $venvPythonPath -ArgumentList "-m pip install -r app/backend/requirements.txt" -Wait -NoNewWindow
+$process = Start-Process -FilePath $venvPythonPath -ArgumentList "-m pip install -r app/backend/requirements.txt" -Wait -NoNewWindow -PassThru
+if ($process.ExitCode -ne 0) {
+    Write-Error "Failed to install dependencies with exit code $($process.ExitCode)"
+    exit $process.ExitCode
+}

--- a/scripts/prepdocs.ps1
+++ b/scripts/prepdocs.ps1
@@ -4,7 +4,7 @@ if ($USE_CLOUD_INGESTION -eq "true") {
   Exit 0
 }
 
-./scripts/load_python_env.ps1
+. ./scripts/load_python_env.ps1
 
 $venvPythonPath = "./.venv/scripts/python.exe"
 if (Test-Path -Path "/usr") {
@@ -26,4 +26,8 @@ $argumentList = "./app/backend/prepdocs.py $dataArg --verbose $additionalArgs"
 
 $argumentList
 
-Start-Process -FilePath $venvPythonPath -ArgumentList $argumentList -Wait -NoNewWindow
+$process = Start-Process -FilePath $venvPythonPath -ArgumentList $argumentList -Wait -NoNewWindow -PassThru
+if ($process.ExitCode -ne 0) {
+    Write-Error "prepdocs.py failed with exit code $($process.ExitCode)"
+    exit $process.ExitCode
+}


### PR DESCRIPTION
## Purpose
We had a requirement to ingest EMAIL files, EML and MSG.   This required a new 'parser' - as well as a new component to display the email, when selected.

Another issue was the "#" character in some fileNames - they would ingest OK, but couldn't use the HREF due to the # within the fileName/Url - rather than DOC.PDF#page1

This PR includes an additional package for the 'extract-msg' - and some CSS tweaks also (for showing MAIL)

## Does this introduce a breaking change?
Have been able to deploy via "AZD DEPLOY" and the processing of EML/MSG files is working - and can view them after a chat or ask response.    ✅

[ X ] Yes
[ ] No
```

## Does this require changes to learn.microsoft.com docs?
No changes to deployment instructions - perhaps need to include details that EML and MSG are supported types.

[ X ] Yes
[ ] No
```

## Type of change

[ X ] Bugfix - with fileName containing "#"
[ X ] Feature - able to ingest EML and MSG
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

