### PR TITLE
Fix last exit code issue

### DIFF
--- a/scripts/load_python_env.sh
+++ b/scripts/load_python_env.sh
@@ -1,6 +1,6 @@
  #!/bin/sh
 
-echo 'Creating Python virtual environment "app/backend/.venv"...'
+echo 'Creating Python virtual environment ".venv"...'
 python3 -m venv .venv
 
 echo 'Installing dependencies from "requirements.txt" into virtual environment (in quiet mode)...'

--- a/scripts/prepdocs.ps1
+++ b/scripts/prepdocs.ps1
@@ -1,5 +1,4 @@
-$USE_CLOUD_INGESTION = (azd env get-value USE_CLOUD_INGESTION)
-if ($USE_CLOUD_INGESTION -eq "true") {
+if ((azd env get-values) -match "USE_CLOUD_INGESTION=""true""") {
   Write-Host "Cloud ingestion is enabled, so we are not running the manual ingestion process."
   Exit 0
 }


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

* Update the powershell script to avoid calling an azd command that sets $LASTEXITCODE to 1
* Update comment in shell script that we are creating the .venv in a different directory

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
