### PR TITLE
fix VSCode 'debug and run'

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,53 +1,50 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Backend (Python)",
-            "type": "debugpy",
-            "request": "launch",
-            "module": "quart",
-            "cwd": "${workspaceFolder}/app/backend",
-            "python": "${workspaceFolder}/.venv/bin/python",
-            "env": {
-                "QUART_APP": "main:app",
-                "QUART_ENV": "development",
-                "QUART_DEBUG": "0",
-                // Set this to "no-override" if you want env vars here to override AZD env vars
-                "LOADING_MODE_FOR_AZD_ENV_VARS": "override"
-            },
-            "args": [
-                "run",
-                "--no-reload",
-                "-p 50505"
-            ],
-            "console": "integratedTerminal",
-            "justMyCode": false
-        },
-        {
-            "name": "Frontend",
-            "type": "node-terminal",
-            "request": "launch",
-            "command": "npm run dev",
-            "cwd": "${workspaceFolder}/app/frontend",
-        },
-        {
-            "name": "Tests (Python)",
-            "type": "debugpy",
-            "request": "launch",
-            "program": "${file}",
-            "purpose": ["debug-test"],
-            "console": "integratedTerminal",
-            "justMyCode": false
-          }
-    ],
-    "compounds": [
-        {
-          "name": "Frontend & Backend",
-          "configurations": ["Backend (Python)", "Frontend"],
-          "stopAll": true
-        }
-    ]
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Backend (Python)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "quart",
+      "cwd": "${workspaceFolder}/app/backend",
+      //MAC uses /bin folder while Windows uses /Scripts, instead use whichever is set as the interpreter
+      "python": "${command:python.interpreterPath}",
+      "env": {
+        "QUART_APP": "main:app",
+        "QUART_ENV": "development",
+        "QUART_DEBUG": "0",
+        // Set this to "no-override" if you want env vars here to override AZD env vars
+        "LOADING_MODE_FOR_AZD_ENV_VARS": "override"
+      },
+      "args": ["run", "--no-reload", "-p 50505"],
+      "console": "integratedTerminal",
+      "justMyCode": false
+    },
+    {
+      "name": "Frontend",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npm run dev",
+      "cwd": "${workspaceFolder}/app/frontend"
+    },
+    {
+      "name": "Tests (Python)",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${file}",
+      "purpose": ["debug-test"],
+      "console": "integratedTerminal",
+      "justMyCode": false
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Frontend & Backend",
+      "configurations": ["Backend (Python)", "Frontend"],
+      "stopAll": true
+    }
+  ]
 }


### PR DESCRIPTION
## Purpose

When using Windows VSCode "run and debug" I am getting following error: 
<img width="695" height="311" alt="image" src="https://github.com/user-attachments/assets/bf33383e-32c5-4d96-9b78-33393c588ba7" />
On Windows, the Python executable inside a virtual environment is located in the **Scripts** folder, not the **bin** folder (which is used for macOS and Linux).

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[ x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[x ] No
```

## Type of change

```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
