### PR TITLE
Fix VS Code debug launch configuration for Windows

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,8 @@
             "request": "launch",
             "module": "quart",
             "cwd": "${workspaceFolder}/app/backend",
-            "python": "${workspaceFolder}/.venv/bin/python",
+            // Use the currently selected interpreter in VS Code. MAC/Linux use /bin, Windows uses /Scripts
+            "python": "${command:python.interpreterPath}",
             "env": {
                 "QUART_APP": "main:app",
                 "QUART_ENV": "development",


### PR DESCRIPTION
## Purpose

When running "debug and run" in VSCode Windows I get following error:

<img width="695" height="311" alt="image" src="https://github.com/user-attachments/assets/1ce18f98-4f9a-4964-9072-561e83ec6777" />

On Windows, the Python executable inside a virtual environment is located in the Scripts folder, not the bin folder (which is used for macOS and Linux).

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x ] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[x ] No
```

## Type of change

```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
