### PR TITLE
Add prompt to review PR comments

### DIFF
--- a/.github/prompts/review_pr_comments.prompt.md
+++ b/.github/prompts/review_pr_comments.prompt.md
@@ -1,7 +1,7 @@
 ---
 agent: agent
 ---
-We have received comments on the current active pull request. Together, we will go through each comment one by one and discuss whether to accept to change, iterate on it, or reject the change.
+We have received comments on the current active pull request. Together, we will go through each comment one by one and discuss whether to accept the change, iterate on it, or reject the change.
 
 ## Steps to follow:
 


### PR DESCRIPTION
## Purpose

This is a prompt I use in my other PRs, to help me triage comments on PRs. It doesn't work perfectly since there's no tool (in GitHub MCP or GitHub CLI) that can reply to each individual comment, but perhaps I can improve that last step in the future with a custom skill.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

N/A