### PR TITLE
Add GitHub PR inline reply skill for Copilot agent

### DIFF
--- a/.github/prompts/review_pr_comments.prompt.md
+++ b/.github/prompts/review_pr_comments.prompt.md
@@ -5,7 +5,7 @@ We have received comments on the current active pull request. Together, we will 
 
 ## Steps to follow:
 
-1. Fetch the active pull request: If available, use the `activePullRequest` tool from the `GitHub Pull Requests` toolset to get the details of the active pull request including the comments. If not, use the GitHub MCP server or GitHub CLI to get the details of the active pull request.
+1. Fetch the active pull request: If available, use the `activePullRequest` tool from the `GitHub Pull Requests` toolset to get the details of the active pull request including the comments. If not, use the GitHub MCP server or GitHub CLI to get the details of the active pull request. Fetch both top level comments and inline comments.
 2. Present a list of the comments with a one-sentence summary of each.
 3. One at a time, present each comment in full detail and ask me whether to accept, iterate, or reject the change. Provide your recommendation for each comment based on best practices, code quality, and project guidelines. Await user's decision before proceeding to the next comment. DO NOT make any changes to the code or files until I have responded with my decision for each comment.
 4. If the decision is to accept or iterate, make the necessary code changes to address the comment. If the decision is to reject, provide a brief explanation of why the change was not made.

--- a/.github/skills/github-pr-inline-reply/SKILL.md
+++ b/.github/skills/github-pr-inline-reply/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: github-pr-inline-reply
+description: Reply to inline PR review comments on GitHub pull requests using the GitHub API. Use this skill when you need to respond to individual review comments on a PR, acknowledge feedback, or mark comments as resolved by posting direct replies to comment threads.
+---
+
+# GitHub PR Inline Reply Skill
+
+This skill enables replying directly to inline review comments on GitHub pull requests.
+
+## When to use
+
+- Replying to individual PR review comments
+- Acknowledging reviewer feedback on specific lines of code
+- Marking review comments as addressed with a reply
+
+## API Endpoint
+
+To reply to an inline PR comment, use:
+
+```http
+POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies
+```
+
+With body:
+
+```json
+{
+  "body": "Your reply message"
+}
+```
+
+## Using gh CLI
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies \
+  -X POST \
+  -f body="Your reply message"
+```
+
+## Workflow
+
+1. **Get PR comments**: First fetch the PR review comments to get their IDs:
+
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/{pull_number}/comments
+   ```
+
+2. **Identify comment IDs**: Each comment has an `id` field. For threaded comments, use the root comment's `id`.
+
+3. **Post replies**: For each comment you want to reply to:
+
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies \
+     -X POST \
+     -f body="Fixed in commit abc123"
+   ```
+
+## Example Replies
+
+For accepted changes:
+
+- "Fixed in {commit_sha}"
+- "Accepted - fixed in {commit_sha}"
+
+For rejected changes:
+
+- "Rejected - {reason}"
+- "Won't fix - {explanation}"
+
+For questions:
+
+- "Good catch, addressed in {commit_sha}"
+
+## Notes
+
+- The `comment_id` is the numeric ID from the comment object, NOT the `node_id`
+- Replies appear as threaded responses under the original comment
+- You can reply to any comment, including bot comments (like Copilot reviews)
+
+## Resolving Conversations
+
+To resolve (mark as resolved) PR review threads, use the GraphQL API:
+
+1. **Get thread IDs**: Query for unresolved threads:
+
+   ```bash
+   gh api graphql -f query='
+   query {
+     repository(owner: "{owner}", name: "{repo}") {
+       pullRequest(number: {pull_number}) {
+         reviewThreads(first: 50) {
+           nodes {
+             id
+             isResolved
+             comments(first: 1) {
+               nodes { body path }
+             }
+           }
+         }
+       }
+     }
+   }'
+   ```
+
+2. **Resolve threads**: Use the `resolveReviewThread` mutation:
+
+   ```bash
+   gh api graphql -f query='
+   mutation {
+     resolveReviewThread(input: {threadId: "PRRT_xxx"}) {
+       thread { isResolved }
+     }
+   }'
+   ```
+
+3. **Resolve multiple threads at once**:
+
+   ```bash
+   gh api graphql -f query='
+   mutation {
+     t1: resolveReviewThread(input: {threadId: "PRRT_xxx"}) { thread { isResolved } }
+     t2: resolveReviewThread(input: {threadId: "PRRT_yyy"}) { thread { isResolved } }
+   }'
+   ```
+
+The thread ID starts with `PRRT_` and can be found in the GraphQL query response.
+
+Note: This skill can be removed once the GitHub MCP server has added built-in support for replying to PR review comments and resolving threads.
+See:
+https://github.com/github/github-mcp-server/issues/1323
+https://github.com/github/github-mcp-server/issues/1768


### PR DESCRIPTION
## Purpose

Adds a new Agent Skill for GitHub Copilot that enables replying directly to inline PR review comments. This skill teaches Copilot how to:

- Reply to individual PR review comments using the GitHub API
- Resolve PR review threads using the GraphQL API
- Use the `gh` CLI to interact with PR comments

This is useful because the GitHub MCP server doesn't yet have built-in support for replying to PR review comments or resolving threads (see [github/github-mcp-server#1323](https://github.com/github/github-mcp-server/issues/1323) and [github/github-mcp-server#1768](https://github.com/github/github-mcp-server/issues/1768)).

Agent Skills follow the [open standard](https://agentskills.io/) and work across VS Code, Copilot CLI, and the Copilot coding agent.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [N/A] I added tests that prove my fix is effective or that my feature works (no code to test, documentation-only skill)
- [N/A] I ran `python -m pytest --cov` to verify 100% coverage of added lines (no Python code added)
- [N/A] I ran `ty check` to check for type errors (no Python code added)
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.