### PR TITLE
Fix devcontainer: remove Yarn repo with expired GPG key

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/devcontainers/python:3.13-bookworm
+
+# Remove Yarn repository with expired GPG key to prevent apt-get update failures
+# Tracking issue: https://github.com/devcontainers/images/issues/1752
+RUN rm -f /etc/apt/sources.list.d/yarn.list

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
     "name": "Azure Search OpenAI Demo",
-    "image": "mcr.microsoft.com/devcontainers/python:3.13-bookworm",
+    // Workaround for https://github.com/devcontainers/images/issues/1752
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
     "features": {
         "ghcr.io/devcontainers/features/node:1": {
             // This should match the version of Node.js in Github Actions workflows


### PR DESCRIPTION
## Purpose

Fixes Codespaces/devcontainer build failure caused by expired Yarn GPG key in the base devcontainer image.

The base image `mcr.microsoft.com/devcontainers/python:3.13-bookworm` has the Yarn apt repository pre-configured, but the GPG signing key has expired. When devcontainer features run `apt-get update`, it fails with:

```
EXPKEYSIG 23E7166788B63E1E Yarn Packaging <yarn@dan.cx>
E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
```

This PR adds a Dockerfile that removes the problematic Yarn repository before features are installed.

Tracking upstream issue: https://github.com/devcontainers/images/issues/1752

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Devcontainer/infrastructure fix
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [N/A] I added tests that prove my fix is effective or that my feature works (devcontainer config change, no code to test)
- [N/A] I ran `python -m pytest --cov` to verify 100% coverage of added lines (no Python code added)
- [N/A] I ran `ty check` to check for type errors (no Python code added)
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.