### PR TITLE
Remove unused --skipblobs argument from prepdocs.py

### DIFF
--- a/app/backend/prepdocs.py
+++ b/app/backend/prepdocs.py
@@ -116,9 +116,6 @@ if __name__ == "__main__":  # pragma: no cover
         "--category", help="Value for the category field in the search index for all sections indexed in this run"
     )
     parser.add_argument(
-        "--skipblobs", action="store_true", help="Skip uploading individual pages to Azure Blob Storage"
-    )
-    parser.add_argument(
         "--disablebatchvectors", action="store_true", help="Don't compute embeddings in batch for the sections"
     )
     parser.add_argument(


### PR DESCRIPTION
## Purpose

Remove the unused `--skipblobs` argument from `prepdocs.py`. This argument was defined but never actually used in the code.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [x] I added tests that prove my fix is effective or that my feature works (N/A - removing dead code)
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines (N/A - no lines added)
- [x] I ran `ty check` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.

## Related issues

Mentioned in #2070
