### PR TITLE
Remove prettier from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,3 @@ repos:
     rev: 26.1.0
     hooks:
     -   id: black
--   repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
-    hooks:
-    - id: prettier
-      types_or: [css, javascript, ts, tsx, html]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,15 @@ If a line starts with a ! (exclamation mark), it means that the line is not cove
 
 ## Sending pull requests
 
-When sending pull requests, make sure to follow the PULL_REQUEST_TEMPLATE.md format.
+When sending pull requests, make sure to follow the [PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) format. This includes:
+
+* **Purpose**: Clearly describe the intention of the changes and what problem it solves or functionality it adds
+* **Breaking changes**: Indicate whether this introduces any breaking changes
+* **Documentation**: Indicate whether any learn.microsoft.com docs need updating
+* **Type of change**: Specify whether this is a bugfix, feature, code style update, refactoring, documentation, or other
+* **Code quality checklist**: Verify that tests pass, coverage is at 100% for new lines, type hints are correct, and code style checks pass
+
+Always populate all sections of the template even if the answer is "No" or "Not applicable".
 
 ## Upgrading dependencies
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,13 +126,7 @@ If a line starts with a ! (exclamation mark), it means that the line is not cove
 
 ## Sending pull requests
 
-When sending pull requests, make sure to follow the [PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) format. This includes:
-
-* **Purpose**: Clearly describe the intention of the changes and what problem it solves or functionality it adds
-* **Breaking changes**: Indicate whether this introduces any breaking changes
-* **Documentation**: Indicate whether any learn.microsoft.com docs need updating
-* **Type of change**: Specify whether this is a bugfix, feature, code style update, refactoring, documentation, or other
-* **Code quality checklist**: Verify that tests pass, coverage is at 100% for new lines, type hints are correct, and code style checks pass
+When sending pull requests, make sure to follow the [PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) format.
 
 Always populate all sections of the template even if the answer is "No" or "Not applicable".
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,9 +126,7 @@ If a line starts with a ! (exclamation mark), it means that the line is not cove
 
 ## Sending pull requests
 
-When sending pull requests, make sure to follow the [PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) format.
-
-Always populate all sections of the template even if the answer is "No" or "Not applicable".
+When sending pull requests, make sure to follow the PULL_REQUEST_TEMPLATE.md format.
 
 ## Upgrading dependencies
 


### PR DESCRIPTION
## Purpose

Removes the archived and unsupported prettier pre-commit hook from the configuration. The `https://github.com/pre-commit/mirrors-prettier` repository is no longer maintained and causes incompatibility issues with the pre-commit framework. This configuration-only change prevents potential issues with the pre-commit workflow.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `ty check` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
