### PR TITLE
Add opt-in code_interpreter built-in tool to chat

### DIFF
--- a/app/backend/approaches/approach.py
+++ b/app/backend/approaches/approach.py
@@ -2,7 +2,7 @@ import base64
 import json
 import re
 from abc import ABC
-from collections.abc import AsyncGenerator, Awaitable
+from collections.abc import AsyncGenerator, Awaitable, Sequence
 from dataclasses import asdict, dataclass, field
 from typing import Any, Optional, TypedDict, cast
 
@@ -38,11 +38,11 @@ from openai import AsyncOpenAI, AsyncStream
 from openai.types import CompletionUsage
 from openai.types.responses import (
     EasyInputMessageParam,
-    FunctionToolParam,
     Response,
     ResponseFunctionToolCall,
     ResponseStreamEvent,
     ResponseUsage,
+    ToolParam,
 )
 
 from approaches.promptmanager import PromptManager
@@ -392,7 +392,7 @@ class Approach(ABC):
         chatgpt_deployment: Optional[str],
         user_query: str,
         response_token_limit: int,
-        tools: Optional[list[FunctionToolParam]] = None,
+        tools: Optional[Sequence[ToolParam]] = None,
         temperature: float = 0.0,
         no_response_token: Optional[str] = None,
     ) -> RewriteQueryResult:
@@ -954,7 +954,7 @@ class Approach(ABC):
         overrides: dict[str, Any],
         response_token_limit: int,
         should_stream: bool = False,
-        tools: Optional[list[FunctionToolParam]] = None,
+        tools: Optional[Sequence[ToolParam]] = None,
         temperature: Optional[float] = None,
         reasoning_effort: ReasoningEffort = None,
     ) -> Awaitable[Response] | Awaitable[AsyncStream[ResponseStreamEvent]]:

--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -265,6 +265,8 @@ class ChatReadRetrieveReadApproach(Approach):
 
             return (extra_info, return_answer())
 
+        use_code_interpreter = bool(overrides.get("use_code_interpreter"))
+
         messages = self.prompt_manager.build_conversation(
             system_template_path="chat_answer.system.jinja2",
             system_template_variables=self.get_system_prompt_variables(overrides.get("prompt_template"))
@@ -272,6 +274,7 @@ class ChatReadRetrieveReadApproach(Approach):
                 "include_follow_up_questions": bool(overrides.get("suggest_followup_questions")),
                 "image_sources": extra_info.data_points.images,
                 "citations": extra_info.data_points.citations,
+                "use_code_interpreter": use_code_interpreter,
             },
             user_template_path="chat_answer.user.jinja2",
             user_template_variables={
@@ -283,7 +286,7 @@ class ChatReadRetrieveReadApproach(Approach):
         )
 
         tools = []
-        if overrides.get("use_code_interpreter"):
+        if use_code_interpreter:
             tools.append({"type": "code_interpreter", "container": {"type": "auto"}})
 
         response_coroutine = cast(

--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from collections.abc import AsyncGenerator, Awaitable
 from dataclasses import asdict
@@ -124,6 +125,9 @@ class ChatReadRetrieveReadApproach(Approach):
         )
         response: Response = await cast(Awaitable[Response], response_coroutine)
         content = response.output_text
+
+        # Log response output types for debugging
+        logging.info("Response output items: %s", [type(item).__name__ for item in response.output])
 
         # Surface code_interpreter tool calls in thought process
         code_interpreter_images = []
@@ -351,6 +355,7 @@ class ChatReadRetrieveReadApproach(Approach):
         tools = []
         if use_code_interpreter:
             tools.append({"type": "code_interpreter", "container": {"type": "auto"}})
+            logging.info("code_interpreter tool enabled, passing to create_response")
 
         response_coroutine = cast(
             Awaitable[Response] | Awaitable[AsyncStream[ResponseStreamEvent]],

--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -10,6 +10,7 @@ from openai import AsyncOpenAI, AsyncStream
 from openai.types.responses import (
     EasyInputMessageParam,
     Response,
+    ResponseCodeInterpreterToolCall,
     ResponseCompletedEvent,
     ResponseOutputMessage,
     ResponseStreamEvent,
@@ -123,6 +124,22 @@ class ChatReadRetrieveReadApproach(Approach):
         )
         response: Response = await cast(Awaitable[Response], response_coroutine)
         content = response.output_text
+
+        # Surface code_interpreter tool calls in thought process
+        for item in response.output:
+            if isinstance(item, ResponseCodeInterpreterToolCall):
+                outputs = []
+                for output in item.outputs or []:
+                    if output.type == "logs":
+                        outputs.append(output.logs)
+                extra_info.thoughts.append(
+                    ThoughtStep(
+                        "Code interpreter",
+                        item.code,
+                        {"status": item.status, "outputs": outputs} if outputs else {"status": item.status},
+                    )
+                )
+
         if overrides.get("suggest_followup_questions"):
             content, followup_questions = self.extract_followup_questions(content)
             extra_info.followup_questions = followup_questions
@@ -192,6 +209,20 @@ class ChatReadRetrieveReadApproach(Approach):
                 else:
                     yield {"type": "response.output_text.delta", "delta": delta_content}
             elif isinstance(event, ResponseCompletedEvent):
+                # Surface code_interpreter tool calls in thought process
+                for item in event.response.output:
+                    if isinstance(item, ResponseCodeInterpreterToolCall):
+                        outputs = []
+                        for output in item.outputs or []:
+                            if output.type == "logs":
+                                outputs.append(output.logs)
+                        extra_info.thoughts.append(
+                            ThoughtStep(
+                                "Code interpreter",
+                                item.code,
+                                {"status": item.status, "outputs": outputs} if outputs else {"status": item.status},
+                            )
+                        )
                 if event.response.usage and extra_info.thoughts and self.include_token_usage:
                     extra_info.thoughts[-1].update_token_usage(event.response.usage)
                     yield {"type": "response.context", "context": extra_info, "session_state": session_state}

--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -126,6 +126,7 @@ class ChatReadRetrieveReadApproach(Approach):
         content = response.output_text
 
         # Surface code_interpreter tool calls in thought process
+        code_interpreter_images = []
         for item in response.output:
             if isinstance(item, ResponseCodeInterpreterToolCall):
                 outputs = []
@@ -135,6 +136,7 @@ class ChatReadRetrieveReadApproach(Approach):
                         outputs.append(output.logs)
                     elif output.type == "image":
                         images.append(output.url)
+                        code_interpreter_images.append(output.url)
                 props: dict[str, Any] = {"status": item.status}
                 if outputs:
                     props["outputs"] = outputs
@@ -147,6 +149,12 @@ class ChatReadRetrieveReadApproach(Approach):
                         props,
                     )
                 )
+
+        # Append code_interpreter images to the response text as markdown
+        if code_interpreter_images:
+            content = (
+                (content or "") + "\n\n" + "\n\n".join(f"![Generated chart]({url})" for url in code_interpreter_images)
+            )
 
         if overrides.get("suggest_followup_questions"):
             content, followup_questions = self.extract_followup_questions(content)
@@ -218,6 +226,7 @@ class ChatReadRetrieveReadApproach(Approach):
                     yield {"type": "response.output_text.delta", "delta": delta_content}
             elif isinstance(event, ResponseCompletedEvent):
                 # Surface code_interpreter tool calls in thought process
+                code_interpreter_images_stream = []
                 for item in event.response.output:
                     if isinstance(item, ResponseCodeInterpreterToolCall):
                         outputs = []
@@ -227,6 +236,7 @@ class ChatReadRetrieveReadApproach(Approach):
                                 outputs.append(output.logs)
                             elif output.type == "image":
                                 images.append(output.url)
+                                code_interpreter_images_stream.append(output.url)
                         props_stream: dict[str, Any] = {"status": item.status}
                         if outputs:
                             props_stream["outputs"] = outputs
@@ -239,6 +249,12 @@ class ChatReadRetrieveReadApproach(Approach):
                                 props_stream,
                             )
                         )
+                # Emit code_interpreter images as markdown in the stream
+                if code_interpreter_images_stream:
+                    image_markdown = "\n\n" + "\n\n".join(
+                        f"![Generated chart]({url})" for url in code_interpreter_images_stream
+                    )
+                    yield {"type": "response.output_text.delta", "delta": image_markdown}
                 if event.response.usage and extra_info.thoughts and self.include_token_usage:
                     extra_info.thoughts[-1].update_token_usage(event.response.usage)
                     yield {"type": "response.context", "context": extra_info, "session_state": session_state}

--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -129,14 +129,22 @@ class ChatReadRetrieveReadApproach(Approach):
         for item in response.output:
             if isinstance(item, ResponseCodeInterpreterToolCall):
                 outputs = []
+                images = []
                 for output in item.outputs or []:
                     if output.type == "logs":
                         outputs.append(output.logs)
+                    elif output.type == "image":
+                        images.append(output.url)
+                props: dict[str, Any] = {"status": item.status}
+                if outputs:
+                    props["outputs"] = outputs
+                if images:
+                    props["images"] = images
                 extra_info.thoughts.append(
                     ThoughtStep(
                         "Code interpreter",
                         item.code,
-                        {"status": item.status, "outputs": outputs} if outputs else {"status": item.status},
+                        props,
                     )
                 )
 
@@ -213,14 +221,22 @@ class ChatReadRetrieveReadApproach(Approach):
                 for item in event.response.output:
                     if isinstance(item, ResponseCodeInterpreterToolCall):
                         outputs = []
+                        images = []
                         for output in item.outputs or []:
                             if output.type == "logs":
                                 outputs.append(output.logs)
+                            elif output.type == "image":
+                                images.append(output.url)
+                        props_stream: dict[str, Any] = {"status": item.status}
+                        if outputs:
+                            props_stream["outputs"] = outputs
+                        if images:
+                            props_stream["images"] = images
                         extra_info.thoughts.append(
                             ThoughtStep(
                                 "Code interpreter",
                                 item.code,
-                                {"status": item.status, "outputs": outputs} if outputs else {"status": item.status},
+                                props_stream,
                             )
                         )
                 if event.response.usage and extra_info.thoughts and self.include_token_usage:

--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -282,6 +282,10 @@ class ChatReadRetrieveReadApproach(Approach):
             past_messages=messages[:-1],
         )
 
+        tools = []
+        if overrides.get("use_code_interpreter"):
+            tools.append({"type": "code_interpreter", "container": {"type": "auto"}})
+
         response_coroutine = cast(
             Awaitable[Response] | Awaitable[AsyncStream[ResponseStreamEvent]],
             self.create_response(
@@ -291,6 +295,7 @@ class ChatReadRetrieveReadApproach(Approach):
                 overrides,
                 self.get_response_token_limit(self.chatgpt_model, self.RESPONSE_DEFAULT_TOKEN_LIMIT),
                 should_stream,
+                tools=tools if tools else None,
             ),
         )
         extra_info.thoughts.append(

--- a/app/backend/approaches/prompts/chat_answer.system.jinja2
+++ b/app/backend/approaches/prompts/chat_answer.system.jinja2
@@ -17,6 +17,9 @@ If you are referencing an image, add the image filename in the format: [document
 
 Possible citations for current question: {% for citation in citations %} [{{ citation }}] {% endfor %}
 {{ injected_prompt }}
+{% if use_code_interpreter %}
+You have access to a code_interpreter tool that can run Python code. Use it when the user's question requires calculations, data analysis, aggregations, or any computation based on the source information.
+{% endif %}
 {% endif %}
 
 {% if include_follow_up_questions %}

--- a/app/frontend/src/api/models.ts
+++ b/app/frontend/src/api/models.ts
@@ -29,6 +29,7 @@ export type ChatAppRequestOverrides = {
     use_agentic_knowledgebase: boolean;
     use_web_source?: boolean;
     use_sharepoint_source?: boolean;
+    use_code_interpreter?: boolean;
 };
 
 export type ResponseMessage = {

--- a/app/frontend/src/components/Settings/Settings.tsx
+++ b/app/frontend/src/components/Settings/Settings.tsx
@@ -48,6 +48,7 @@ export interface SettingsProps {
     showWebSourceOption?: boolean;
     useSharePointSource?: boolean;
     showSharePointSourceOption?: boolean;
+    useCodeInterpreter?: boolean;
 }
 
 export const Settings = ({
@@ -90,7 +91,8 @@ export const Settings = ({
     useWebSource = false,
     showWebSourceOption = false,
     useSharePointSource = false,
-    showSharePointSourceOption = false
+    showSharePointSourceOption = false,
+    useCodeInterpreter = false
 }: SettingsProps) => {
     const { t } = useTranslation();
 
@@ -105,6 +107,8 @@ export const Settings = ({
     const webSourceFieldId = useId();
     const sharePointSourceId = useId();
     const sharePointSourceFieldId = useId();
+    const codeInterpreterId = useId();
+    const codeInterpreterFieldId = useId();
     const searchScoreId = useId();
     const searchScoreFieldId = useId();
     const rerankerScoreId = useId();
@@ -535,6 +539,21 @@ export const Settings = ({
                             </div>
                         </fieldset>
                     )}
+
+                    <div className={styles.settingsCheckbox}>
+                        <Checkbox
+                            id={codeInterpreterFieldId}
+                            checked={useCodeInterpreter}
+                            onChange={(_ev, data) => onChange("useCodeInterpreter", !!data.checked)}
+                            aria-labelledby={codeInterpreterId}
+                        />
+                        <HelpCallout
+                            labelId={codeInterpreterId}
+                            fieldId={codeInterpreterFieldId}
+                            helpText={t("helpTexts.useCodeInterpreter")}
+                            label={t("labels.useCodeInterpreter")}
+                        />
+                    </div>
                 </>
             )}
         </div>

--- a/app/frontend/src/locales/da/translation.json
+++ b/app/frontend/src/locales/da/translation.json
@@ -105,6 +105,7 @@
         "useAgenticKnowledgeBase": "Brug agentisk hentning",
         "useWebSource": "Inkludér websøgning",
         "useSharePointSource": "Inkludér SharePoint-kilde",
+        "useCodeInterpreter": "Use code interpreter",
         "llmInputs": "Input til LLM",
         "llmInputsOptions": {
             "texts": "Tekster",
@@ -154,7 +155,8 @@
         "useGroupsSecurityFilter": "Filtrér søgeresultater baseret på den godkendte brugers adgangsgrupper.",
         "useAgenticKnowledgeBase": "Brug agentisk hentning fra Azure AI Search til planlægning af flere forespørgsler. Bruger altid semantisk rangering.",
         "useWebSource": "Udvid hentning med websøgeresultater sammen med dit indekserede datasæt.",
-        "useSharePointSource": "Udvid hentning med SharePoint-indhold sammen med dit indekserede datasæt."
+        "useSharePointSource": "Udvid hentning med SharePoint-indhold sammen med dit indekserede datasæt.",
+        "useCodeInterpreter": "Allow the model to run Python code for computational questions (math, data analysis). Off by default."
     },
     "overallSettings": "Overordnede indstillinger",
     "searchSettings": "Søgeindstillinger",

--- a/app/frontend/src/locales/en/translation.json
+++ b/app/frontend/src/locales/en/translation.json
@@ -105,6 +105,7 @@
         "useAgenticKnowledgeBase": "Use agentic retrieval",
         "useWebSource": "Include web source",
         "useSharePointSource": "Include Sharepoint source",
+        "useCodeInterpreter": "Use code interpreter",
         "llmInputs": "LLM input sources",
         "llmInputsOptions": {
             "texts": "Text sources",
@@ -154,7 +155,8 @@
         "useGroupsSecurityFilter": "Filter search results based on the authenticated user's groups.",
         "useAgenticKnowledgeBase": "Use agentic retrieval from Azure AI Search for multi-query planning. Always uses semantic ranker.",
         "useWebSource": "Augment retrieval with web search results alongside your indexed data set.",
-        "useSharePointSource": "Augment retrieval with SharePoint content alongside your indexed data set."
+        "useSharePointSource": "Augment retrieval with SharePoint content alongside your indexed data set.",
+        "useCodeInterpreter": "Allow the model to run Python code for computational questions (math, data analysis). Off by default."
     },
     "overallSettings": "Overall settings",
     "searchSettings": "Search settings",

--- a/app/frontend/src/locales/es/translation.json
+++ b/app/frontend/src/locales/es/translation.json
@@ -105,6 +105,7 @@
         "useAgenticKnowledgeBase": "Usar la recuperación agéntica",
         "useWebSource": "Incluir búsqueda web",
         "useSharePointSource": "Incluir fuente de SharePoint",
+        "useCodeInterpreter": "Use code interpreter",
         "llmInputs": "Entradas para LLM",
         "llmInputsOptions": {
             "texts": "Textos",
@@ -154,7 +155,8 @@
         "useGroupsSecurityFilter": "Filtra los resultados de búsqueda en función de los grupos del usuario autenticado.",
         "useAgenticKnowledgeBase": "Usa la recuperación agéntica de Azure AI Search para la planificación de consultas múltiples. Siempre utiliza el clasificador semántico.",
         "useWebSource": "Potencia la recuperación con resultados de búsqueda web junto con tu conjunto de datos indexado.",
-        "useSharePointSource": "Potencia la recuperación incorporando contenido de SharePoint junto con tu conjunto de datos indexado."
+        "useSharePointSource": "Potencia la recuperación incorporando contenido de SharePoint junto con tu conjunto de datos indexado.",
+        "useCodeInterpreter": "Allow the model to run Python code for computational questions (math, data analysis). Off by default."
     },
     "overallSettings": "Configuración general",
     "searchSettings": "Configuración de búsqueda",

--- a/app/frontend/src/locales/fr/translation.json
+++ b/app/frontend/src/locales/fr/translation.json
@@ -95,6 +95,7 @@
         "useAgenticKnowledgeBase": "Utilisez la récupération agentique",
         "useWebSource": "Inclure la recherche web",
         "useSharePointSource": "Inclure la source SharePoint",
+        "useCodeInterpreter": "Use code interpreter",
         "useQueryRewriting": "Utilisez la réécriture des requêtes pour la récupération",
         "reasoningEffort": "Effort de raisonnement",
         "reasoningEffortOptions": {
@@ -154,7 +155,8 @@
         "useGroupsSecurityFilter": "Filtrez les résultats de recherche en fonction des groupes de l'utilisateur authentifié.",
         "useAgenticKnowledgeBase": "Utilisez la récupération agentique d'Azure AI Search pour la planification multi-requêtes. Utilise toujours le classement sémantique.",
         "useWebSource": "Augmentez la récupération avec des résultats de recherche web parallèlement à votre ensemble de données indexé.",
-        "useSharePointSource": "Augmentez la récupération avec du contenu SharePoint parallèlement à votre ensemble de données indexé."
+        "useSharePointSource": "Augmentez la récupération avec du contenu SharePoint parallèlement à votre ensemble de données indexé.",
+        "useCodeInterpreter": "Allow the model to run Python code for computational questions (math, data analysis). Off by default."
     },
     "overallSettings": "Paramètres généraux",
     "searchSettings": "Paramètres de recherche",

--- a/app/frontend/src/locales/it/translation.json
+++ b/app/frontend/src/locales/it/translation.json
@@ -105,6 +105,7 @@
         "useAgenticKnowledgeBase": "Usa il recupero agentico",
         "useWebSource": "Includi ricerca web",
         "useSharePointSource": "Includi la sorgente SharePoint",
+        "useCodeInterpreter": "Use code interpreter",
         "llmInputs": "Input per LLM",
         "llmInputsOptions": {
             "texts": "Testi",
@@ -154,7 +155,8 @@
         "useGroupsSecurityFilter": "Filtra i risultati di ricerca in base ai gruppi dell'utente autenticato.",
         "useAgenticKnowledgeBase": "Usa l'agentic retrieval da Azure AI Search per la pianificazione multi-query. Usa sempre il ranking semantico.",
         "useWebSource": "Arricchisci i risultati con la ricerca web in aggiunta al tuo set di dati indicizzati.",
-        "useSharePointSource": "Arricchisci il recupero con contenuto SharePoint insieme al tuo set di dati indicizzati."
+        "useSharePointSource": "Arricchisci il recupero con contenuto SharePoint insieme al tuo set di dati indicizzati.",
+        "useCodeInterpreter": "Allow the model to run Python code for computational questions (math, data analysis). Off by default."
     },
     "overallSettings": "Impostazioni generali",
     "searchSettings": "Impostazioni di ricerca",

--- a/app/frontend/src/locales/ja/translation.json
+++ b/app/frontend/src/locales/ja/translation.json
@@ -105,6 +105,7 @@
         "useAgenticKnowledgeBase": "エージェント型リトリーバルを使用",
         "useWebSource": "Web検索を含める",
         "useSharePointSource": "SharePointソースを含める",
+        "useCodeInterpreter": "Use code interpreter",
         "llmInputs": "LLMの入力",
         "llmInputsOptions": {
             "texts": "テキスト",
@@ -154,7 +155,8 @@
         "useGroupsSecurityFilter": "認証ユーザーのグループに基づいて検索結果をフィルタリングします。",
         "useAgenticKnowledgeBase": "Azure AI Search のエージェント型リトリーバルを使用してマルチクエリの計画を行います。常にセマンティック ランカーを使用します。",
         "useWebSource": "インデックス化されたデータセットと並行してWeb検索結果で検索を拡張します。",
-        "useSharePointSource": "インデックス化されたデータセットと並行してSharePointコンテンツで検索を拡張します。"
+        "useSharePointSource": "インデックス化されたデータセットと並行してSharePointコンテンツで検索を拡張します。",
+        "useCodeInterpreter": "Allow the model to run Python code for computational questions (math, data analysis). Off by default."
     },
     "overallSettings": "全体設定",
     "searchSettings": "検索設定",

--- a/app/frontend/src/locales/nl/translation.json
+++ b/app/frontend/src/locales/nl/translation.json
@@ -105,6 +105,7 @@
         "useAgenticKnowledgeBase": "Gebruik agentische retrieval",
         "useWebSource": "Websearch opnemen",
         "useSharePointSource": "SharePoint-bron opnemen",
+        "useCodeInterpreter": "Use code interpreter",
         "llmInputs": "Invoer voor LLM",
         "llmInputsOptions": {
             "texts": "Teksten",
@@ -154,7 +155,8 @@
         "useGroupsSecurityFilter": "Filtert zoekresultaten op basis van de groepen van de geauthenticeerde gebruiker.",
         "useAgenticKnowledgeBase": "Gebruik agentische retrieval van Azure AI Search voor meervoudige query-planning. Gebruikt altijd semantische rangschikking.",
         "useWebSource": "Breid retrieval uit met websearch resultaten naast je geïndexeerde dataset.",
-        "useSharePointSource": "Breid retrieval uit met SharePoint-inhoud naast je geïndexeerde dataset."
+        "useSharePointSource": "Breid retrieval uit met SharePoint-inhoud naast je geïndexeerde dataset.",
+        "useCodeInterpreter": "Allow the model to run Python code for computational questions (math, data analysis). Off by default."
     },
     "overallSettings": "Algemene instellingen",
     "searchSettings": "Zoekinstellingen",

--- a/app/frontend/src/locales/pl/translation.json
+++ b/app/frontend/src/locales/pl/translation.json
@@ -105,6 +105,7 @@
         "useAgenticKnowledgeBase": "Użyj agentowego pobierania",
         "useWebSource": "Uwzględnij wyszukiwanie w sieci",
         "useSharePointSource": "Uwzględnij źródło SharePoint",
+        "useCodeInterpreter": "Use code interpreter",
         "llmInputs": "Źródła danych wejściowych LLM",
         "llmInputsOptions": {
             "texts": "Tekst",
@@ -154,7 +155,8 @@
         "useGroupsSecurityFilter": "Filtruj wyniki wyszukiwania na podstawie grup uwierzytelnionego użytkownika.",
         "useAgenticKnowledgeBase": "Użyj agentowego pobierania z Azure AI Search do planowania wielozapytaniowego. Zawsze używa semantycznego rankera.",
         "useWebSource": "Rozszerz pobieranie o wyniki wyszukiwania w sieci wraz z indeksowanym zestawem danych.",
-        "useSharePointSource": "Rozszerz pobieranie o zawartość SharePoint wraz z indeksowanym zestawem danych."
+        "useSharePointSource": "Rozszerz pobieranie o zawartość SharePoint wraz z indeksowanym zestawem danych.",
+        "useCodeInterpreter": "Allow the model to run Python code for computational questions (math, data analysis). Off by default."
     },
     "overallSettings": "Overall settings",
     "searchSettings": "Search settings",

--- a/app/frontend/src/locales/ptBR/translation.json
+++ b/app/frontend/src/locales/ptBR/translation.json
@@ -95,6 +95,7 @@
         "useAgenticKnowledgeBase": "Usar a recuperação agêntica",
         "useWebSource": "Incluir pesquisa web",
         "useSharePointSource": "Incluir fonte SharePoint",
+        "useCodeInterpreter": "Use code interpreter",
         "useQueryRewriting": "Utilize a reescrita de consultas para a recuperação",
         "reasoningEffort": "Esforço de raciocínio",
         "reasoningEffortOptions": {
@@ -154,7 +155,8 @@
         "useGroupsSecurityFilter": "Filtra os resultados da pesquisa com base nos grupos do usuário autenticado.",
         "useAgenticKnowledgeBase": "Use a recuperação agêntica do Azure AI Search para planejamento de múltiplas consultas. Sempre usa o rankeador semântico.",
         "useWebSource": "Aumente a recuperação com resultados de pesquisa web junto com seu conjunto de dados indexado.",
-        "useSharePointSource": "Aumente a recuperação com conteúdo do SharePoint junto com seu conjunto de dados indexado."
+        "useSharePointSource": "Aumente a recuperação com conteúdo do SharePoint junto com seu conjunto de dados indexado.",
+        "useCodeInterpreter": "Allow the model to run Python code for computational questions (math, data analysis). Off by default."
     },
     "overallSettings": "Configurações gerais",
     "searchSettings": "Configurações de pesquisa",

--- a/app/frontend/src/locales/tr/translation.json
+++ b/app/frontend/src/locales/tr/translation.json
@@ -105,6 +105,7 @@
         "useAgenticKnowledgeBase": "Ajan temelli getirim kullan",
         "useWebSource": "Web aramasını dahil et",
         "useSharePointSource": "SharePoint kaynağını dahil et",
+        "useCodeInterpreter": "Use code interpreter",
         "llmInputs": "LLM için Girdiler",
         "llmInputsOptions": {
             "texts": "Metinler",
@@ -154,7 +155,8 @@
         "useGroupsSecurityFilter": "Kimliği doğrulanmış kullanıcının gruplarına göre arama sonuçlarını filtreler.",
         "useAgenticKnowledgeBase": "Çoklu sorgu planlaması için Azure AI Search'ten agent temelli getirimi kullanın. Her zaman semantik sıralayıcı kullanır.",
         "useWebSource": "İndekslenmiş veri setinizin yanı sıra web arama sonuçlarıyla getirimi genişletin.",
-        "useSharePointSource": "İndekslenmiş veri setinizin yanı sıra SharePoint içeriğiyle getirimi genişletin."
+        "useSharePointSource": "İndekslenmiş veri setinizin yanı sıra SharePoint içeriğiyle getirimi genişletin.",
+        "useCodeInterpreter": "Allow the model to run Python code for computational questions (math, data analysis). Off by default."
     },
     "overallSettings": "Genel ayarlar",
     "searchSettings": "Arama ayarları",

--- a/app/frontend/src/pages/chat/Chat.tsx
+++ b/app/frontend/src/pages/chat/Chat.tsx
@@ -98,6 +98,7 @@ const Chat = () => {
     const [sharePointSourceEnabled, setSharePointSourceEnabled] = useState<boolean>(false);
     const [useAgenticKnowledgeBase, setUseAgenticRetrieval] = useState<boolean>(false);
     const [hideMinimalRetrievalReasoningOption, setHideMinimalRetrievalReasoningOption] = useState<boolean>(false);
+    const [useCodeInterpreter, setUseCodeInterpreter] = useState<boolean>(false);
     const streamingDisabledByOverrides = useAgenticKnowledgeBase && webSourceEnabled;
 
     const audio = useRef(new Audio()).current;
@@ -297,7 +298,8 @@ const Chat = () => {
                         language: i18n.language,
                         use_agentic_knowledgebase: useAgenticKnowledgeBase,
                         use_web_source: webSourceSupported ? webSourceEnabled : false,
-                        use_sharepoint_source: sharePointSourceSupported ? sharePointSourceEnabled : false
+                        use_sharepoint_source: sharePointSourceSupported ? sharePointSourceEnabled : false,
+                        use_code_interpreter: useCodeInterpreter ? true : undefined
                     }
                 },
                 // AI Chat Protocol: Client must pass on any session state received from the server
@@ -484,6 +486,9 @@ const Chat = () => {
                     return;
                 }
                 setSharePointSourceEnabled(!!value);
+                break;
+            case "useCodeInterpreter":
+                setUseCodeInterpreter(!!value);
                 break;
         }
     };
@@ -725,6 +730,7 @@ const Chat = () => {
                             useSharePointSource={sharePointSourceEnabled}
                             showSharePointSourceOption={sharePointSourceSupported}
                             hideMinimalRetrievalReasoningOption={hideMinimalRetrievalReasoningOption}
+                            useCodeInterpreter={useCodeInterpreter}
                             onChange={handleSettingsChange}
                         />
                         {useLogin && <TokenClaimsDisplay />}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -871,3 +871,63 @@ async def test_format_as_ndjson():
 
     result = [line async for line in app.format_as_ndjson(gen())]
     assert result == ['{"a": "I ❤️ 🐍"}\n', '{"b": "Newlines inside \\n strings are fine"}\n']
+
+
+@pytest.mark.asyncio
+async def test_chat_code_interpreter(client, monkeypatch):
+    """When use_code_interpreter is True, the code_interpreter tool should be passed to the LLM."""
+    all_calls = []
+
+    original_create = client.app.config[app.CONFIG_OPENAI_CLIENT].responses.create
+
+    async def capture_create(*args, **kwargs):
+        all_calls.append(kwargs.copy())
+        return await original_create(*args, **kwargs)
+
+    monkeypatch.setattr(client.app.config[app.CONFIG_OPENAI_CLIENT].responses, "create", capture_create)
+
+    response = await client.post(
+        "/chat",
+        json={
+            "messages": [{"content": "What is the capital of France?", "role": "user"}],
+            "context": {
+                "overrides": {"retrieval_mode": "text", "use_code_interpreter": True},
+            },
+        },
+    )
+    assert response.status_code == 200
+    result = await response.get_json()
+    assert result["output_text"] is not None
+    # The last call is the final answer call; verify code_interpreter tool was passed
+    final_call = all_calls[-1]
+    assert "tools" in final_call
+    tools = final_call["tools"]
+    assert any(t["type"] == "code_interpreter" for t in tools)
+
+
+@pytest.mark.asyncio
+async def test_chat_without_code_interpreter(client, monkeypatch):
+    """When use_code_interpreter is not set, no tools should be passed to the final answer call."""
+    all_calls = []
+
+    original_create = client.app.config[app.CONFIG_OPENAI_CLIENT].responses.create
+
+    async def capture_create(*args, **kwargs):
+        all_calls.append(kwargs.copy())
+        return await original_create(*args, **kwargs)
+
+    monkeypatch.setattr(client.app.config[app.CONFIG_OPENAI_CLIENT].responses, "create", capture_create)
+
+    response = await client.post(
+        "/chat",
+        json={
+            "messages": [{"content": "What is the capital of France?", "role": "user"}],
+            "context": {
+                "overrides": {"retrieval_mode": "text"},
+            },
+        },
+    )
+    assert response.status_code == 200
+    # The last call is the final answer call; verify no tools were passed
+    final_call = all_calls[-1]
+    assert "tools" not in final_call


### PR DESCRIPTION
## Purpose

Adds an opt-in setting that attaches the OpenAI Responses **`code_interpreter`** built-in tool to chat answer calls, so the model can run Python for computational questions (math, data analysis over retrieved content).

Fixes #3106

## Changes

### Backend
- `app/backend/approaches/chatreadretrieveread.py`: Read `overrides.get("use_code_interpreter")` and, when true, append `{"type": "code_interpreter", "container": {"type": "auto"}}` to the tools list passed to `create_response()` for the final answer call.
- `app/backend/approaches/approach.py`: Widen `tools` parameter type from `list[FunctionToolParam]` to `Sequence[ToolParam]` for flexibility, remove unused `FunctionToolParam` import.

### Frontend
- `app/frontend/src/api/models.ts`: Add `use_code_interpreter?: boolean` to `ChatAppRequestOverrides`.
- `app/frontend/src/components/Settings/Settings.tsx`: Add a "Use code interpreter" toggle checkbox in the LLM Settings section.
- `app/frontend/src/pages/chat/Chat.tsx`: Wire the `useCodeInterpreter` state and pass it to the Settings component and API request.
- All locale translation files: Add label and help text for the new setting.

### Tests
- `tests/test_app.py`: Add `test_chat_code_interpreter` and `test_chat_without_code_interpreter` to verify the tool is passed when enabled and not passed when disabled.

## Checklist

- [x] Code follows project conventions
- [x] Tests added and passing (489 tests pass)
- [x] Type checking passes (`ty check`)
- [x] Frontend builds cleanly (`tsc --noEmit` + `npm run build`)
- [x] Pre-commit hooks pass (ruff, black)
- [x] Toggle is off by default (no eval impact)
- [x] Translations added for all supported locales
