### PR TITLE
Make local dev server port configurable via PORT/BACKEND_PORT env vars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,13 @@ To avoid port conflicts (e.g. if another instance is already running), pick a ra
 PORT=50506 ./app/start.sh
 ```
 
+On Windows (PowerShell):
+
+```powershell
+$env:PORT = 50506
+./app/start.ps1
+```
+
 If you also need the frontend dev server with hot reloading (for UI changes), run it separately with the matching `BACKEND_PORT`:
 
 ```shell

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,28 @@ We only enforce type hints in the main application code and scripts.
 
 Do not use single underscores in front of "private" methods or variables in Python code. We do not follow that convention in this codebase, since this is an application and not a library.
 
+## Starting the app locally
+
+The simplest way to start the app is with `./app/start.sh` (or `./app/start.ps1` on Windows). This builds the frontend and starts the backend — no separate frontend process needed unless you want hot reloading.
+
+To avoid port conflicts (e.g. if another instance is already running), pick a random port:
+
+```shell
+PORT=50506 ./app/start.sh
+```
+
+If you also need the frontend dev server with hot reloading (for UI changes), run it separately with the matching `BACKEND_PORT`:
+
+```shell
+# Terminal 1: backend
+PORT=50506 ./app/start.sh
+
+# Terminal 2: frontend with HMR
+cd app/frontend && BACKEND_PORT=50506 npm run dev
+```
+
+**Tips for coding agents**: Always specify your own random port via `PORT` to avoid colliding with a developer's running instance or other parallel agents. The start scripts will detect if the port is already in use and tell you to pick a different one.
+
 ## Deploying the application
 
 To deploy the application, use the `azd` CLI tool. Make sure you have the latest version of the `azd` CLI installed. Then, run the following command from the root of the repository:

--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -34,6 +34,7 @@
       "devDependencies": {
         "@types/dom-speech-recognition": "^0.0.7",
         "@types/dompurify": "^3.2.0",
+        "@types/node": "^26.0.1",
         "@types/react": "^19.2.13",
         "@types/react-dom": "^19.2.3",
         "@types/react-syntax-highlighter": "^15.5.13",
@@ -3042,6 +3043,16 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/prismjs": {
       "version": "1.26.5",
       "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
@@ -5661,6 +5672,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@types/dom-speech-recognition": "^0.0.7",
     "@types/dompurify": "^3.2.0",
+    "@types/node": "^26.0.1",
     "@types/react": "^19.2.13",
     "@types/react-dom": "^19.2.3",
     "@types/react-syntax-highlighter": "^15.5.13",

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -2,42 +2,46 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
-export default defineConfig({
-    plugins: [react()],
-    resolve: {
-        preserveSymlinks: true
-    },
-    build: {
-        outDir: "../backend/static",
-        emptyOutDir: true,
-        sourcemap: true,
-        rollupOptions: {
-            output: {
-                manualChunks: id => {
-                    if (id.includes("@fluentui/react-icons")) {
-                        return "fluentui-icons";
-                    } else if (id.includes("@fluentui/react")) {
-                        return "fluentui-react";
-                    } else if (id.includes("node_modules")) {
-                        return "vendor";
+export default defineConfig(() => {
+    const backendPort = process.env.BACKEND_PORT ?? "50505";
+    const backendUrl = `http://localhost:${backendPort}`;
+    return {
+        plugins: [react()],
+        resolve: {
+            preserveSymlinks: true
+        },
+        build: {
+            outDir: "../backend/static",
+            emptyOutDir: true,
+            sourcemap: true,
+            rollupOptions: {
+                output: {
+                    manualChunks: id => {
+                        if (id.includes("@fluentui/react-icons")) {
+                            return "fluentui-icons";
+                        } else if (id.includes("@fluentui/react")) {
+                            return "fluentui-react";
+                        } else if (id.includes("node_modules")) {
+                            return "vendor";
+                        }
                     }
                 }
-            }
+            },
+            target: "esnext"
         },
-        target: "esnext"
-    },
-    server: {
-        proxy: {
-            "/content/": "http://localhost:50505",
-            "/auth_setup": "http://localhost:50505",
-            "/.auth/me": "http://localhost:50505",
-            "/chat": "http://localhost:50505",
-            "/speech": "http://localhost:50505",
-            "/config": "http://localhost:50505",
-            "/upload": "http://localhost:50505",
-            "/delete_uploaded": "http://localhost:50505",
-            "/list_uploaded": "http://localhost:50505",
-            "/chat_history": "http://localhost:50505"
+        server: {
+            proxy: {
+                "/content/": backendUrl,
+                "/auth_setup": backendUrl,
+                "/.auth/me": backendUrl,
+                "/chat": backendUrl,
+                "/speech": backendUrl,
+                "/config": backendUrl,
+                "/upload": backendUrl,
+                "/delete_uploaded": backendUrl,
+                "/list_uploaded": backendUrl,
+                "/chat_history": backendUrl
+            }
         }
-    }
+    };
 });

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -3,7 +3,7 @@ import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig(() => {
-    const backendPort = process.env.BACKEND_PORT ?? "50505";
+    const backendPort = process.env.BACKEND_PORT || "50505";
     const backendUrl = `http://localhost:${backendPort}`;
     return {
         plugins: [react()],

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 

--- a/app/start.ps1
+++ b/app/start.ps1
@@ -70,9 +70,13 @@ Set-Location ../backend
 
 $port = if ($env:PORT) { $env:PORT } else { 50505 }
 $hostname = "localhost"
-if (Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue) {
-    Write-Host "Port $port is already in use. Set env:PORT to use a different port."
-    exit 1
+try {
+    if (Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue) {
+        Write-Host "Port $port is already in use. Set env:PORT to use a different port."
+        exit 1
+    }
+} catch {
+    # Non-numeric or out-of-range port; let Quart handle validation
 }
 Start-Process -FilePath $venvPythonPath -ArgumentList "-m quart --app main:app run --port $port --host $hostname --reload" -Wait -NoNewWindow
 

--- a/app/start.ps1
+++ b/app/start.ps1
@@ -70,6 +70,10 @@ Set-Location ../backend
 
 $port = if ($env:PORT) { $env:PORT } else { 50505 }
 $hostname = "localhost"
+if (Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue) {
+    Write-Host "Port $port is already in use. Set env:PORT to use a different port."
+    exit 1
+}
 Start-Process -FilePath $venvPythonPath -ArgumentList "-m quart --app main:app run --port $port --host $hostname --reload" -Wait -NoNewWindow
 
 if ($LASTEXITCODE -ne 0) {

--- a/app/start.ps1
+++ b/app/start.ps1
@@ -68,7 +68,7 @@ Write-Host "Starting backend"
 Write-Host ""
 Set-Location ../backend
 
-$port = 50505
+$port = if ($env:PORT) { $env:PORT } else { 50505 }
 $hostname = "localhost"
 Start-Process -FilePath $venvPythonPath -ArgumentList "-m quart --app main:app run --port $port --host $hostname --reload" -Wait -NoNewWindow
 

--- a/app/start.ps1
+++ b/app/start.ps1
@@ -70,13 +70,9 @@ Set-Location ../backend
 
 $port = if ($env:PORT) { $env:PORT } else { 50505 }
 $hostname = "localhost"
-try {
-    if (Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue) {
-        Write-Host "Port $port is already in use. Set env:PORT to use a different port."
-        exit 1
-    }
-} catch {
-    # Non-numeric or out-of-range port; let Quart handle validation
+if (Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue) {
+    Write-Host "Port $port is already in use. Set env:PORT to use a different port."
+    exit 1
 }
 Start-Process -FilePath $venvPythonPath -ArgumentList "-m quart --app main:app run --port $port --host $hostname --reload" -Wait -NoNewWindow
 

--- a/app/start.sh
+++ b/app/start.sh
@@ -48,7 +48,7 @@ echo ""
 
 cd ../backend
 
-port=50505
+port=${PORT:-50505}
 host=localhost
 ../../.venv/bin/python -m quart --app main:app run --port "$port" --host "$host" --reload
 out=$?

--- a/app/start.sh
+++ b/app/start.sh
@@ -50,7 +50,7 @@ cd ../backend
 
 port=${PORT:-50505}
 host=localhost
-if lsof -i :"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+if command -v lsof >/dev/null 2>&1 && lsof -i :"$port" -sTCP:LISTEN >/dev/null 2>&1; then
     echo "Port $port is already in use. Set PORT=<number> to use a different port."
     exit 1
 fi

--- a/app/start.sh
+++ b/app/start.sh
@@ -50,6 +50,10 @@ cd ../backend
 
 port=${PORT:-50505}
 host=localhost
+if lsof -i :"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+    echo "Port $port is already in use. Set PORT=<number> to use a different port."
+    exit 1
+fi
 ../../.venv/bin/python -m quart --app main:app run --port "$port" --host "$host" --reload
 out=$?
 if [ $out -ne 0 ]; then


### PR DESCRIPTION
## Purpose

Make the local development server port configurable via environment variables, allowing multiple instances to run in parallel without port collisions.

Fixes #3116

## Changes

1. **`app/start.sh`**: Replace `port=50505` with `port=${PORT:-50505}` so the backend port reads from the `PORT` env var with a fallback to 50505. Added port-in-use detection with a helpful error message.
2. **`app/start.ps1`**: Replace `$port = 50505` with `$port = if ($env:PORT) { $env:PORT } else { 50505 }` for the same behavior on Windows. Added port-in-use detection.
3. **`app/frontend/vite.config.ts`**: Convert the config to a function form and read `process.env.BACKEND_PORT || "50505"` to construct proxy targets dynamically.

## Usage

- **Default (unchanged behavior)**: `./app/start.sh` → backend on 50505; `npm run dev` proxies to 50505.
- **Custom port**: `PORT=50506 ./app/start.sh` → backend on 50506; `BACKEND_PORT=50506 npm run dev` → vite proxies to 50506.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

- [x] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `ty check` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
