### PR TITLE
Add ACL count action to manageacl.py

### DIFF
--- a/scripts/manageacl.py
+++ b/scripts/manageacl.py
@@ -84,6 +84,8 @@ class ManageAcl:
                 await self.remove_all_acls(search_client)
             elif self.acl_action == "add":
                 await self.add_acl(search_client)
+            elif self.acl_action == "count":
+                await self.count_acls(search_client)
             elif self.acl_action == "update_storage_urls":
                 await self.update_storage_urls(search_client)
             elif self.acl_action == "enable_global_access":
@@ -142,6 +144,14 @@ class ManageAcl:
             await search_client.merge_documents(documents=documents_to_merge)
         else:
             logger.info("Not updating any search documents")
+
+    async def count_acls(self, search_client: SearchClient):
+        acl_counts = {}
+        for document in await self.get_documents(search_client):
+            for acl_value in set(document[self.acl_type]):
+                acl_counts[acl_value] = acl_counts.get(acl_value, 0) + 1
+
+        print(json.dumps(acl_counts, sort_keys=True))
 
     async def get_documents(self, search_client: SearchClient):
         filter = f"storageUrl eq '{self.url}'"
@@ -296,7 +306,16 @@ if __name__ == "__main__":
     parser.add_argument(
         "--acl-action",
         required=False,
-        choices=["remove", "add", "view", "remove_all", "enable_acls", "update_storage_urls", "enable_global_access"],
+        choices=[
+            "remove",
+            "add",
+            "view",
+            "count",
+            "remove_all",
+            "enable_acls",
+            "update_storage_urls",
+            "enable_global_access",
+        ],
         help="Optional. Whether to remove or add the ACL to the document, or enable acls on the index",
     )
     parser.add_argument("--acl", required=False, default=None, help="Optional. Value of ACL to add or remove.")

--- a/tests/test_manageacl.py
+++ b/tests/test_manageacl.py
@@ -90,6 +90,34 @@ async def test_view_acl(monkeypatch, capsys):
 
 
 @pytest.mark.asyncio
+async def test_count_acls(monkeypatch, capsys):
+    async def mock_search(self, *args, **kwargs):
+        assert kwargs.get("filter") == "storageUrl eq 'https://test.blob.core.windows.net/content/a.txt'"
+        assert kwargs.get("select") == ["id", "oids"]
+        return AsyncSearchResultsIterator(
+            [
+                {"id": 1, "oids": ["OID_SHARED", "OID_UNIQUE_1"]},
+                {"id": 2, "oids": ["OID_SHARED", "OID_UNIQUE_2", "OID_UNIQUE_2"]},
+            ]
+        )
+
+    monkeypatch.setattr(SearchClient, "search", mock_search)
+
+    command = ManageAcl(
+        service_name="SERVICE",
+        index_name="INDEX",
+        url="https://test.blob.core.windows.net/content/a.txt",
+        acl_action="count",
+        acl_type="oids",
+        acl="",
+        credentials=MockAzureCredential(),
+    )
+    await command.run()
+    captured = capsys.readouterr()
+    assert captured.out.strip() == '{"OID_SHARED": 2, "OID_UNIQUE_1": 1, "OID_UNIQUE_2": 1}'
+
+
+@pytest.mark.asyncio
 async def test_remove_acl(monkeypatch, capsys):
     async def mock_search(self, *args, **kwargs):
         assert kwargs.get("filter") == "storageUrl eq 'https://test.blob.core.windows.net/content/a.txt'"


### PR DESCRIPTION
## Summary\nAdd a read-only `count` action to `scripts/manageacl.py` that prints a JSON summary of how many documents contain each ACL value for the selected ACL field.\n\n## Testing\n- `pytest tests/test_manageacl.py`\n\nCloses #3115