### PR TITLE
Deploy OpenAI account as AIServices (Foundry) kind

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -785,7 +785,7 @@ module openAi 'br/public:avm/res/cognitive-services/account:0.7.2' = if (isAzure
     name: !empty(openAiServiceName) ? openAiServiceName : '${abbrs.cognitiveServicesAccounts}${resourceToken}'
     location: openAiLocation
     tags: tags
-    kind: 'OpenAI'
+    kind: 'AIServices'
     customSubDomainName: !empty(openAiServiceName)
       ? openAiServiceName
       : '${abbrs.cognitiveServicesAccounts}${resourceToken}'


### PR DESCRIPTION
## Purpose

Fixes #3084.

Change the kind of the Azure OpenAI cognitive services account provisioned by [infra/main.bicep](infra/main.bicep#L788) from `'OpenAI'` to `'AIServices'` so the deployed resource shows up as a Foundry project resource in the portal. This lets users connect the same account to Foundry agents/tools and switch between models exposed through the Responses API, while keeping the existing Chat + RAG flow working unchanged.

`AIServices` is a superset of the `OpenAI` account kind:

- It supports the same OpenAI model deployments (`format: 'OpenAI'`), so all existing `openAiDeployments` (chat, embedding, eval, agentic knowledge base) continue to deploy the same way.
- It still exposes the `<name>.openai.azure.com` endpoint the backend already builds in `servicesetup.py`, so no application code changes are needed.
- It still honors `disableLocalAuth` and `restore`.
- The existing `privatelink.openai.azure.com` private DNS zone continues to resolve the OpenAI endpoint used by the app.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?

```
[ ] Yes
[x] No
```

Existing environments will see the resource kind flip from `OpenAI` to `AIServices` on the next `azd provision` / `azd up`. Azure allows this in-place upgrade and the existing deployments, endpoint, and role assignments continue to work.

## Does this require changes to learn.microsoft.com docs?

```
[ ] Yes
[x] No
```

## Type of change

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

- [x] The current tests all pass (`python -m pytest`). N/A — infra-only change, not covered by pytest.
- [ ] I added tests that prove my fix is effective or that my feature works — N/A, Bicep change only.
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines — N/A.
- [ ] I ran `ty check` to check for type errors — N/A.
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.