### PR TITLE
chore(deps): upgrade msal to 1.37.0 and cryptography to 49.0.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,14 +204,15 @@ Use a dedicated azd env with login + access control enabled so the OBO code path
 1. **Create the env and enable auth:**
 
    ```shell
-   azd env new pf-ragchat-login --subscription <SUB_ID> --location eastus2
+   azd env new pf-ragchat-login --subscription <SUB_ID> --location <REGION>
    azd env set AZURE_USE_AUTHENTICATION true
    azd env set AZURE_ENFORCE_ACCESS_CONTROL true
    azd env set AZURE_ENABLE_UNAUTHENTICATED_ACCESS false
    azd env set AZURE_AUTH_TENANT_ID <YOUR_TENANT_ID>
    azd env set AZURE_TENANT_ID <YOUR_TENANT_ID>
-   # If eastus2 is capacity-constrained for Search:
-   azd env set AZURE_SEARCH_SERVICE_LOCATION westus3
+   # If the chosen region is capacity-constrained for Azure AI Search,
+   # override just the Search location:
+   azd env set AZURE_SEARCH_SERVICE_LOCATION <OTHER_REGION>
    ```
 
 2. **Provision + deploy:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,69 @@ To upgrade a particular package in the frontend:
 * For major version upgrades of UI libraries like Fluent UI or MSAL, review breaking changes carefully. Manual tests are required for any MSAL changes since the E2E tests do not cover authentication flows.
 * If npm reports peer dependency conflicts, the `.npmrc` file has `legacy-peer-deps=true` which allows the install to proceed. This is currently needed because `react-helmet-async` declares peer dependencies on React 17/18, but works fine with React 19.
 
+## Manual test plan for authentication changes (msal, msal-browser, authentication.py)
+
+The unit tests mock `msal` at the client level, so any change to `msal`, `@azure/msal-browser`, `cryptography`, or `app/backend/core/authentication.py` needs a live deploy against Entra to confirm the on-behalf-of (OBO) flow, token cache, and Container Apps Easy Auth integration still work.
+
+Use a dedicated azd env with login + access control enabled so the OBO code path is actually exercised.
+
+1. **Create the env and enable auth:**
+
+   ```shell
+   azd env new pf-ragchat-login --subscription <SUB_ID> --location eastus2
+   azd env set AZURE_USE_AUTHENTICATION true
+   azd env set AZURE_ENFORCE_ACCESS_CONTROL true
+   azd env set AZURE_ENABLE_UNAUTHENTICATED_ACCESS false
+   azd env set AZURE_AUTH_TENANT_ID <YOUR_TENANT_ID>
+   azd env set AZURE_TENANT_ID <YOUR_TENANT_ID>
+   # If eastus2 is capacity-constrained for Search:
+   azd env set AZURE_SEARCH_SERVICE_LOCATION westus3
+   ```
+
+2. **Provision + deploy:**
+
+   ```shell
+   ./scripts/auth_init.sh   # creates the client + server Entra app registrations
+   azd up -e pf-ragchat-login
+   ```
+
+   `azd up` runs `auth_update.sh` as a postprovision hook to update the client app's redirect URIs.
+
+3. **Ingest data for this env.** The `.md5` marker files under `data/` are shared across envs and cause `prepdocs` to skip everything on a fresh env, leaving the search index empty. Remove them first, then re-ingest:
+
+   ```shell
+   rm data/*.md5
+   ./scripts/prepdocs.sh
+   ```
+
+4. **Apply an ACL to at least one document for your user oid** (find your oid via `az ad signed-in-user show --query id -o tsv`):
+
+   ```shell
+   python scripts/manageacl.py -v --acl-action add --acl-type oids \
+     --acl <YOUR_OID> \
+     --url "https://<storage-account>.blob.core.windows.net/content/Northwind_Standard_Benefits_Details.pdf"
+   ```
+
+5. **Verify auth enforcement with curl** (both should return `HTTP 401` because Container Apps Easy Auth blocks unauthenticated traffic before the app sees the request):
+
+   ```shell
+   BASE=https://<your-backend-fqdn>
+   curl -sS -o /dev/null -w "%{http_code}\n" "$BASE/auth_setup"
+   curl -sS -o /dev/null -w "%{http_code}\n" -X POST "$BASE/chat" \
+     -H "Content-Type: application/json" \
+     -d '{"messages":[{"role":"user","content":"hi"}]}'
+   ```
+
+6. **Verify the OBO flow in the browser:**
+   * Load the app URL — you should be redirected to Entra sign-in.
+   * Sign in with the tenant user whose oid you ACL'd.
+   * Ask a question that only the ACL'd document can answer (e.g. "What is included in the Northwind Standard plan?"). You should get an answer with citations only from that document.
+   * Ask a question about a document that is NOT ACL'd to you (e.g. "What is included in the Northwind Health Plus plan?"). You should get "I don't know" / no citations. This confirms the OBO token was issued by `msal.ConfidentialClientApplication.acquire_token_on_behalf_of` and correctly passed to Azure AI Search as the access-control filter.
+
+7. **Optional: log out and reload.** Confirms Easy Auth logout works and re-auth kicks in cleanly.
+
+If any step fails, check container logs — `AuthError` from `app/backend/core/authentication.py` usually indicates the OBO token exchange or token validation broke.
+
 ## Checking Python type hints
 
 To check Python type hints, use the following command:

--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -18,6 +18,8 @@ anyio==4.4.0
     #   openai
 asgiref==3.10.0
     # via opentelemetry-instrumentation-asgi
+async-timeout==5.0.1
+    # via aiohttp
 attrs==25.3.0
     # via aiohttp
 azure-ai-documentintelligence==1.0.2
@@ -83,7 +85,7 @@ click==8.4.1
     #   flask
     #   quart
     #   uvicorn
-cryptography==46.0.7
+cryptography==49.0.0
     # via
     #   -r requirements.in
     #   azure-identity
@@ -92,6 +94,11 @@ cryptography==46.0.7
     #   pyjwt
 distro==1.9.0
     # via openai
+exceptiongroup==1.3.1
+    # via
+    #   anyio
+    #   hypercorn
+    #   taskgroup
 flask==3.1.3
     # via quart
 frozenlist==1.8.0
@@ -112,7 +119,7 @@ hpack==4.1.0
     # via h2
 httpcore==1.0.9
     # via httpx
-httpx[http2]==0.28.1
+httpx==0.28.1
     # via
     #   microsoft-kiota-http
     #   msgraph-core
@@ -178,7 +185,7 @@ microsoft-kiota-serialization-multipart==1.9.3
     # via msgraph-sdk
 microsoft-kiota-serialization-text==1.9.3
     # via msgraph-sdk
-msal==1.33.0
+msal==1.37.0
     # via
     #   -r requirements.in
     #   azure-identity
@@ -329,7 +336,7 @@ pydantic-core==2.46.4
     # via pydantic
 pygments==2.20.0
     # via rich
-pyjwt[crypto]==2.12.0
+pyjwt==2.12.0
     # via
     #   -r requirements.in
     #   msal
@@ -366,10 +373,14 @@ soupsieve==2.8.4
     # via beautifulsoup4
 std-uritemplate==2.0.8
     # via microsoft-kiota-abstractions
+taskgroup==0.2.2
+    # via hypercorn
 tenacity==9.1.4
     # via -r requirements.in
 tiktoken==0.12.0
     # via -r requirements.in
+tomli==2.4.1
+    # via hypercorn
 tqdm==4.66.5
     # via openai
 types-beautifulsoup4==4.12.0.20250516
@@ -381,6 +392,10 @@ types-pillow==10.2.0.20240822
 typing-extensions==4.15.0
     # via
     #   -r requirements.in
+    #   aiohttp
+    #   aiosignal
+    #   anyio
+    #   asgiref
     #   azure-ai-documentintelligence
     #   azure-core
     #   azure-cosmos
@@ -389,13 +404,20 @@ typing-extensions==4.15.0
     #   azure-storage-blob
     #   azure-storage-file-datalake
     #   beautifulsoup4
+    #   cryptography
+    #   exceptiongroup
+    #   hypercorn
+    #   multidict
     #   openai
     #   opentelemetry-api
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
     #   pydantic
     #   pydantic-core
+    #   pypdf
+    #   taskgroup
     #   typing-inspection
+    #   uvicorn
 typing-inspection==0.4.2
     # via pydantic
 urllib3==2.7.0


### PR DESCRIPTION
## Purpose

Dependabot's PR #3113 to upgrade `cryptography` from 46.0.7 to 48.0.1 failed because `msal` 1.33.0 pins `cryptography<47`. Upgrading them together resolves the conflict:

- `msal`: 1.33.0 → 1.37.0
- `cryptography`: 46.0.7 → 49.0.0

Regenerated `app/backend/requirements.txt` via:

```shell
cd app/backend && uv pip compile requirements.in -o requirements.txt --python-version 3.10 --upgrade-package msal --upgrade-package cryptography
```

The function `requirements.txt` files (`document_extractor`, `figure_processor`, `text_processor`) are gitignored and get synced from the backend requirements at build time by `scripts/copy_prepdocslib.py`, so no changes to those are needed in-repo.

Closes #3113.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

```
[ ] Yes
[x] No
```

## Type of change

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

- [x] The current tests all pass (`python -m pytest`) — 493 passed locally.
- [ ] I added tests that prove my fix is effective or that my feature works — N/A (dependency version bump).
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines — N/A (no code changes).
- [ ] I ran `ty check` to check for type errors — N/A (no code changes).
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.