### PR TITLE
chore(deps): upgrade @azure/msal-browser to 5.17 and @azure/msal-react to 5.5

### DIFF
--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -8,8 +8,8 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@azure/msal-browser": "^4.16.0",
-        "@azure/msal-react": "^3.0.16",
+        "@azure/msal-browser": "^5.17.0",
+        "@azure/msal-react": "^5.5.2",
         "@fluentui/react-components": "^9.73.3",
         "@fluentui/react-icons": "^2.0.319",
         "@fluentui/react-table": "^9.19.14",
@@ -49,37 +49,37 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.16.0.tgz",
-      "integrity": "sha512-yF8gqyq7tVnYftnrWaNaxWpqhGQXoXpDfwBtL7UCGlIbDMQ1PUJF/T2xCL6NyDNHoO70qp1xU8GjjYTyNIefkw==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.17.0.tgz",
+      "integrity": "sha512-/yTnW2TCk9Mh+2b/NOaHAN+MryUNxzRTaJD/YtrqOA9bpBWfTXn/iyReRbaLrK/btBo3stEzLyEvuWp2NZ5DuA==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.9.0"
+        "@azure/msal-common": "16.11.1"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.9.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.9.0.tgz",
-      "integrity": "sha512-lbz/D+C9ixUG3hiZzBLjU79a0+5ZXCorjel3mwXluisKNH0/rOS/ajm8yi4yI9RP5Uc70CAcs9Ipd0051Oh/kA==",
+      "version": "16.11.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.1.tgz",
+      "integrity": "sha512-yPohvMwWLv1XnaWnIUyKUh8CvcVChCGqG/VluGwfGmaAfrZTNt5yQ+sIs462Sgw6+e2K83KGmMJ860p73ZSCrw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-react": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-3.0.16.tgz",
-      "integrity": "sha512-fIFc3z9UrHoOCG4rApNWMRr83DnQlo+CHfLSPNBQa4rndIkr+XYBpdYDqlzqtmikRf3A+CYNVOQ+lQX6jM0zdw==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-5.5.2.tgz",
+      "integrity": "sha512-gqLSay+1NfOjDUNL/A64myLhbPck/ne8Gw6O4Yb14Y/U/7AntnJs1Fzwyxt5AxOMnBkfzl9loDpBas2fugkwXw==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@azure/msal-browser": "^4.16.0",
-        "react": "^16.8.0 || ^17 || ^18 || ^19"
+        "@azure/msal-browser": "^5.17.0",
+        "react": "^16.8.0 || ^17 || ^18 || ^19.2.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -13,8 +13,8 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "@azure/msal-browser": "^4.16.0",
-    "@azure/msal-react": "^3.0.16",
+    "@azure/msal-browser": "^5.17.0",
+    "@azure/msal-react": "^5.5.2",
     "@fluentui/react-components": "^9.73.3",
     "@fluentui/react-icons": "^2.0.319",
     "@fluentui/react-table": "^9.19.14",


### PR DESCRIPTION
## Purpose

Bumps the frontend MSAL libraries together (they're peer-related and best upgraded as a pair):

- `@azure/msal-browser`: `^4.16.0` → `^5.17.0`
- `@azure/msal-react`: `^3.0.16` → `^5.5.2`

Manually QA'd against a login + access-control-enforced deploy following the [Manual test plan for authentication changes](../AGENTS.md#manual-test-plan-for-authentication-changes-msal-msal-browser-authenticationpy) in AGENTS.md:

- Fresh browser → redirected to Entra sign-in ✅
- Signed in, asked about an ACL'd doc (Northwind Standard) → answered with citations ✅
- Asked about a non-ACL'd doc (Northwind Health Plus) → correctly returned "I don't know" ✅
- `curl /chat` and `curl /auth_setup` unauthenticated → both return 401 ✅
- `npm run build` clean, no code changes required

Supersedes dependabot PRs #3087 (msal-browser 5.15.0) and #2946 (msal-react 5.0.3) — both should auto-close on merge.

Note: an unrelated CORS-on-logout issue was observed in the browser console (already tracked in #1780 / #2102 — not caused by this bump).

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Dependency bump (frontend MSAL libraries)
```

## Code quality checklist

- [x] The current tests all pass (`python -m pytest`) — frontend build clean, e2e tests don't cover MSAL flows so manual QA against a login-enabled deploy was performed.
- [x] I added tests that prove my fix is effective or that my feature works — N/A (dependency bump; e2e tests intentionally don't cover MSAL — see AGENTS.md manual test plan).
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines — N/A (no code changes).
- [x] I ran `ty check` to check for type errors — N/A (no Python changes).
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.