### PR TITLE
chore(deps): upgrade msgraph-sdk to 1.58.0 and microsoft-kiota-* to 1.11.7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,6 +259,54 @@ Use a dedicated azd env with login + access control enabled so the OBO code path
 
 If any step fails, check container logs — `AuthError` from `app/backend/core/authentication.py` usually indicates the OBO token exchange or token validation broke.
 
+## Manual test plan for msgraph-sdk / microsoft-kiota-* changes
+
+`msgraph-sdk` (and its transitive `microsoft-kiota-*` deps) is only imported by `scripts/auth_init.py` and `scripts/auth_update.py`, which register Entra client + server apps for the login-enabled deploy. The unit tests in `tests/test_auth_init.py` mock `GraphServiceClient` end-to-end, so a bump can pass CI while breaking a real Graph call (usually due to renamed request-body classes or new required fields).
+
+Validate against a live tenant using the same `pf-ragchat-login` env from the msal test plan:
+
+1. **First run — exercises PATCH + query paths only.** If the client and server app registrations from a prior run already exist, `auth_init.sh` short-circuits the `applications.post()` create path:
+
+   ```shell
+   ./scripts/auth_init.sh
+   ```
+
+   Look for `Application already exists, not creating new one` — that means the POST paths were skipped. The PATCH paths (`applications.by_application_id().patch()`) for permissions + known-client-apps *did* run, plus `oauth2_permission_grants` queries.
+
+2. **Force the create path** to exercise `applications.post()`, `service_principals.post()`, and `applications.by_application_id().add_password.post()` (where major SDK bumps most often break):
+
+   ```shell
+   # Grab the existing app IDs from the azd env
+   CLIENT_APP=$(azd env get-value AZURE_CLIENT_APP_ID)
+   SERVER_APP=$(azd env get-value AZURE_SERVER_APP_ID)
+
+   # Delete both Entra app registrations (safe on a test env)
+   az ad app delete --id $CLIENT_APP
+   az ad app delete --id $SERVER_APP
+
+   # Clear the cached IDs and secrets so auth_init recreates from scratch
+   azd env set AZURE_CLIENT_APP_ID ""
+   azd env set AZURE_CLIENT_APP_SECRET ""
+   azd env set AZURE_SERVER_APP_ID ""
+   azd env set AZURE_SERVER_APP_SECRET ""
+
+   ./scripts/auth_init.sh
+   ```
+
+   You should see `Creating application registration` (twice — once for server, once for client), followed by `Granted admin consent for ...` messages. Every msgraph SDK code path in `auth_init.py` is now exercised.
+
+3. **Test the update path** by running the postprovision hook that updates client-app redirect URIs:
+
+   ```shell
+   ./scripts/auth_update.sh
+   ```
+
+   Look for `Application update for client app id ... complete.`
+
+4. **Re-run the msal test plan** end-to-end (browser sign-in, ACL'd doc question, non-ACL'd doc question) since the fresh apps will have new client IDs. `azd deploy backend` after `auth_init.sh` picks up the new IDs.
+
+If POST fails with a serialization / model-class error (e.g. `AttributeError` on a model instance, or a 400 from Graph complaining about a missing property), the bumped SDK likely renamed or relocated a request-body class. Check the msgraph-sdk release notes and update the corresponding import in `scripts/auth_init.py`.
+
 ## Checking Python type hints
 
 To check Python type hints, use the following command:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,7 +263,7 @@ If any step fails, check container logs — `AuthError` from `app/backend/core/a
 
 `msgraph-sdk` (and its transitive `microsoft-kiota-*` deps) is only imported by `scripts/auth_init.py` and `scripts/auth_update.py`, which register Entra client + server apps for the login-enabled deploy. The unit tests in `tests/test_auth_init.py` mock `GraphServiceClient` end-to-end, so a bump can pass CI while breaking a real Graph call (usually due to renamed request-body classes or new required fields).
 
-Validate against a live tenant using the same `pf-ragchat-login` env from the msal test plan:
+Validate against a live tenant. If you don't already have a login-enabled deploy, follow steps 1–2 of the msal test plan above to create + provision an auth-enabled azd env (any env name works — the steps below use `$AZURE_ENV_NAME` from your current azd env).
 
 1. **First run — exercises PATCH + query paths only.** If the client and server app registrations from a prior run already exist, `auth_init.sh` short-circuits the `applications.post()` create path:
 

--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -164,7 +164,7 @@ markupsafe==3.0.3
     #   werkzeug
 mdurl==0.1.2
     # via markdown-it-py
-microsoft-kiota-abstractions==1.9.10
+microsoft-kiota-abstractions==1.11.7
     # via
     #   microsoft-kiota-authentication-azure
     #   microsoft-kiota-http
@@ -173,17 +173,17 @@ microsoft-kiota-abstractions==1.9.10
     #   microsoft-kiota-serialization-multipart
     #   microsoft-kiota-serialization-text
     #   msgraph-core
-microsoft-kiota-authentication-azure==1.9.3
+microsoft-kiota-authentication-azure==1.11.7
     # via msgraph-core
-microsoft-kiota-http==1.9.9
+microsoft-kiota-http==1.11.7
     # via msgraph-core
-microsoft-kiota-serialization-form==1.9.3
+microsoft-kiota-serialization-form==1.11.7
     # via msgraph-sdk
-microsoft-kiota-serialization-json==1.9.3
+microsoft-kiota-serialization-json==1.11.7
     # via msgraph-sdk
-microsoft-kiota-serialization-multipart==1.9.3
+microsoft-kiota-serialization-multipart==1.11.7
     # via msgraph-sdk
-microsoft-kiota-serialization-text==1.9.3
+microsoft-kiota-serialization-text==1.11.7
     # via msgraph-sdk
 msal==1.37.0
     # via
@@ -192,9 +192,9 @@ msal==1.37.0
     #   msal-extensions
 msal-extensions==1.3.1
     # via azure-identity
-msgraph-core==1.3.3
+msgraph-core==1.4.0
     # via msgraph-sdk
-msgraph-sdk==1.45.0
+msgraph-sdk==1.58.0
     # via -r requirements.in
 msrest==0.7.1
     # via azure-monitor-opentelemetry-exporter


### PR DESCRIPTION
## Purpose

Bumps the msgraph SDK and all `microsoft-kiota-*` transitive deps together (they all release in lockstep):

- `msgraph-sdk`: 1.45.0 → 1.58.0
- `msgraph-core`: 1.3.3 → 1.4.0
- `microsoft-kiota-abstractions`: 1.9.10 → 1.11.7
- `microsoft-kiota-authentication-azure`: 1.9.3 → 1.11.7
- `microsoft-kiota-http`: 1.9.9 → 1.11.7
- `microsoft-kiota-serialization-form`: 1.9.3 → 1.11.7
- `microsoft-kiota-serialization-json`: 1.9.3 → 1.11.7
- `microsoft-kiota-serialization-multipart`: 1.9.3 → 1.11.7
- `microsoft-kiota-serialization-text`: 1.9.3 → 1.11.7

Regenerated `app/backend/requirements.txt` with the same `uv pip compile` command documented in AGENTS.md.

`msgraph-sdk` is only used by `scripts/auth_init.py` and `scripts/auth_update.py` (for Entra app registration + redirect-URI updates). No backend runtime code imports it. The bundled azure-functions and container app don't exercise it.

**Verified:**
- All 493 tests pass locally
- `./scripts/auth_init.sh` succeeded end-to-end against a live Entra tenant — checked existing client + server app registrations, verified permissions, verified admin consent
- `./scripts/auth_update.sh` succeeded — updated client app redirect URIs

Supersedes dependabot PRs #3088 (kiota-serialization-text 1.11.7) and #2969 (kiota-serialization-json 1.9.8). Both should auto-close on merge.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Dependency bump (msgraph-sdk + microsoft-kiota-*)
```

## Code quality checklist

- [x] The current tests all pass (`python -m pytest`) — 493 passed locally.
- [ ] I added tests that prove my fix is effective or that my feature works — N/A (dependency bump; smoke-tested via live `./scripts/auth_init.sh` + `./scripts/auth_update.sh` against Entra).
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines — N/A (no code changes).
- [ ] I ran `ty check` to check for type errors — N/A (no code changes).
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.