### PR TITLE
fix(auth): regenerate secrets when Entra apps are recreated after manual deletion

### DIFF
--- a/scripts/auth_init.py
+++ b/scripts/auth_init.py
@@ -78,7 +78,7 @@ async def create_or_update_application_with_secret(
         update_azd_env(app_id_env_var, app_id)
         created_app = True
 
-    if object_id and os.getenv(app_secret_env_var, "no-secret") == "no-secret":
+    if object_id and (os.getenv(app_secret_env_var, "no-secret") == "no-secret" or created_app):
         print(f"Adding client secret to {app_id}")
         client_secret = await add_client_secret(graph_client, object_id)
         update_azd_env(app_secret_env_var, client_secret)

--- a/tests/test_auth_init.py
+++ b/tests/test_auth_init.py
@@ -268,6 +268,44 @@ async def test_create_or_update_application_existing_with_secret(graph_client, m
     assert len(graph._test_calls["applications.add_password.post"]) == 0
 
 
+@pytest.mark.asyncio
+async def test_create_or_update_application_recreates_with_stale_secret(graph_client, monkeypatch):
+    """When the Entra app was deleted manually but stale AZURE_*_APP_SECRET remains in env,
+    a new app is created and a fresh secret must be generated to replace the stale one.
+    Regression test for https://github.com/Azure-Samples/azure-search-openai-demo/issues/2522."""
+    graph = graph_client
+    updates: list[tuple[str, str]] = []
+
+    def fake_update_env(name, val):
+        updates.append((name, val))
+
+    # Both env vars are set but point to a deleted app + stale secret
+    with mock.patch.dict(
+        os.environ, {"AZURE_SERVER_APP_ID": "DELETED_APP", "AZURE_SERVER_APP_SECRET": "STALE"}, clear=True
+    ):
+        monkeypatch.setattr(auth_init, "update_azd_env", fake_update_env)
+
+        # get_application returns None for the deleted app id -> triggers create path
+        async def fake_get_application(graph_client, client_id):
+            return None
+
+        monkeypatch.setattr("scripts.auth_init.get_application", fake_get_application)
+        object_id, app_id, created = await create_or_update_application_with_secret(
+            graph,
+            app_id_env_var="AZURE_SERVER_APP_ID",
+            app_secret_env_var="AZURE_SERVER_APP_SECRET",
+            request_app=server_app_initial(99),
+        )
+        assert created is True
+        assert object_id == MOCK_OBJECT_ID
+        assert app_id == MOCK_APP_ID
+        # Both app id AND secret must be refreshed even though stale values were in env
+        assert ("AZURE_SERVER_APP_ID", MOCK_APP_ID) in updates
+        assert ("AZURE_SERVER_APP_SECRET", MOCK_SECRET) in updates
+    # A new secret must be requested from Graph
+    assert len(graph._test_calls["applications.add_password.post"]) == 1
+
+
 def test_client_app_validation_errors():
     # Server app without api
     server_app = server_app_initial(1)


### PR DESCRIPTION
## Purpose

Fixes #2522. Supersedes #2737.

When Entra client + server app registrations are manually deleted but the azd env still holds the old `AZURE_CLIENT_APP_ID` / `AZURE_SERVER_APP_ID` and their corresponding `_SECRET` values, `scripts/auth_init.py` correctly recreates the applications (because `get_application` returns `None` for the stale IDs) — but it does **not** regenerate the client secrets. The stale secrets get written back into the env, and every subsequent request fails auth.

### Fix

One-line change in `create_or_update_application_with_secret`: also add a fresh secret when we've just created the app, not only when the secret env var is missing.

```diff
-    if object_id and os.getenv(app_secret_env_var, "no-secret") == "no-secret":
+    if object_id and (os.getenv(app_secret_env_var, "no-secret") == "no-secret" or created_app):
```

### Tests

Added `test_create_or_update_application_recreates_with_stale_secret` to `tests/test_auth_init.py` matching the existing mock-graph fixture style. Verified the test fails on `main` and passes with the fix. All 14 tests in `tests/test_auth_init.py` pass.

### Live verification

Reproduced end-to-end against a live Entra tenant on a login-enabled deploy (see the "Manual test plan for msgraph-sdk / microsoft-kiota-* changes" section in AGENTS.md):

1. Deleted both Entra app registrations with `az ad app delete`, **left** the stale `AZURE_*_APP_ID` and `AZURE_*_APP_SECRET` values in the azd env.
2. Ran `./scripts/auth_init.sh`.
3. Both `Creating application registration` and `Adding client secret to <new-app-id>` fired for each app.
4. Compared the azd env secret values before/after — both `AZURE_CLIENT_APP_SECRET` and `AZURE_SERVER_APP_SECRET` were replaced with fresh values.

### Difference from #2737

Same one-line source fix. This PR uses the existing `tests/test_auth_init.py` fixture (real `GraphServiceClient` with mocked HTTP adapter — added after #2737 was opened) instead of adding a parallel test file. Rebased on latest main.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

```
[ ] Yes
[x] No
```

## Type of change

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

- [x] The current tests all pass (`python -m pytest`) — 14/14 in `tests/test_auth_init.py`.
- [x] I added tests that prove my fix is effective — new regression test fails on main and passes with the fix.
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines — N/A (single-line change, covered by new + existing tests).
- [x] I ran `ty check` to check for type errors — no relevant changes to type surface.
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.