### PR TITLE
fix(infra): use resolved storage account name for aca-auth token store

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -686,7 +686,7 @@ module acaAuth 'core/host/container-apps-auth.bicep' = if (deploymentTarget == '
     clientSecretSettingName: !empty(clientAppSecret) ? 'azureclientappsecret' : ''
     authenticationIssuerUri: authenticationIssuerUri
     enableUnauthenticatedAccess: enableUnauthenticatedAccess
-    blobContainerUri: 'https://${storageAccountName}.blob.${environment().suffixes.storage}/${tokenStorageContainerName}'
+    blobContainerUri: 'https://${storage.outputs.name}.blob.${environment().suffixes.storage}/${tokenStorageContainerName}'
     appIdentityResourceId: (deploymentTarget == 'appservice') ? '' : acaBackend!.outputs.identityResourceId
   }
 }


### PR DESCRIPTION
## Purpose

Fixes a bug that breaks any Container Apps deployment with `AZURE_USE_AUTHENTICATION=true`.

In `infra/main.bicep`, the `blobContainerUri` for the `aca-auth` token store used the `storageAccountName` **param** (which is empty by default) instead of the resolved storage module output. The empty interpolation produced an invalid URI:

```
https://.blob.core.windows.net/tokens
```

…and provisioning failed with:

```
AuthConfigInvalidRequest: AuthConfig is invalid with detail 'Invalid blobContainerUri 
'https://.blob.core.windows.net/tokens'. The URI must use HTTPS and the host must be
a valid Azure Blob Storage endpoint (e.g. 'https://myaccount.blob.core.windows.net/mycontainer').'
```

Fix: use `storage.outputs.name` (the resolved account name), consistent with every other reference in the file.

Reproduced on a fresh env with `AZURE_USE_AUTHENTICATION=true`, `AZURE_ENFORCE_ACCESS_CONTROL=true`; provision failed at the `aca-auth` module. After the one-line change, `azd provision` and `azd deploy` succeeded and the app authenticates as expected.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

```
[ ] Yes
[x] No
```

## Type of change

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

- [x] The current tests all pass (`python -m pytest`) — N/A for Bicep-only change; verified via successful end-to-end `azd up` on a login-enabled env.
- [ ] I added tests that prove my fix is effective or that my feature works — N/A (Bicep infra fix; validated by successful deployment).
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines — N/A.
- [ ] I ran `ty check` to check for type errors — N/A.
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.