### PR TITLE
Handle Easy Auth redirect on /auth_setup fetch to fix CORS after logout

### DIFF
--- a/app/frontend/src/authConfig.ts
+++ b/app/frontend/src/authConfig.ts
@@ -64,7 +64,10 @@ async function fetchAuthSetup(): Promise<AuthSetup> {
         // Reload the current page so the browser handles the login flow, then never resolve
         // so the rest of the module does not try to initialize with a missing AuthSetup.
         window.location.reload();
-        return new Promise<AuthSetup>(() => {});
+        return new Promise<AuthSetup>(() => {
+            /* Intentionally never resolve: window.location.reload() above is about to unload this page,
+               so no caller should proceed past this await. Do not "clean up" this empty executor. */
+        });
     }
     if (!response.ok) {
         throw new Error(`auth setup response was not ok: ${response.status}`);

--- a/app/frontend/src/authConfig.ts
+++ b/app/frontend/src/authConfig.ts
@@ -54,7 +54,18 @@ interface AuthSetup {
 
 // Fetch the auth setup JSON data from the API if not already cached
 async function fetchAuthSetup(): Promise<AuthSetup> {
-    const response = await fetch("/auth_setup");
+    // Use redirect: "manual" so that a 302 to a cross-origin login provider (e.g. login.microsoftonline.com)
+    // returned by Container Apps / App Service Easy Auth does not trigger a CORS error on this XHR.
+    // See https://github.com/Azure-Samples/azure-search-openai-demo/issues/1780
+    const response = await fetch("/auth_setup", { redirect: "manual" });
+    if (response.type === "opaqueredirect") {
+        // Easy Auth wants to redirect us to the identity provider to (re-)authenticate.
+        // A top-level navigation can follow the cross-origin 302; fetch cannot.
+        // Reload the current page so the browser handles the login flow, then never resolve
+        // so the rest of the module does not try to initialize with a missing AuthSetup.
+        window.location.reload();
+        return new Promise<AuthSetup>(() => {});
+    }
     if (!response.ok) {
         throw new Error(`auth setup response was not ok: ${response.status}`);
     }


### PR DESCRIPTION
## Purpose

Fixes #1780 (also closes duplicate #2102).

When the app is deployed with Entra login enabled (Container Apps / App Service Easy Auth) and the user's session cookie is missing or expired — for example immediately after signing out — the very first request the SPA makes is a `fetch("/auth_setup")` from [`app/frontend/src/authConfig.ts`](app/frontend/src/authConfig.ts). Easy Auth intercepts that request before it reaches the backend and responds with a `302` to `https://login.microsoftonline.com/...`. Because `fetch` follows redirects by default and the target is cross-origin without the required CORS headers, the browser surfaces this to the app as a CORS error, the top-level `await fetchAuthSetup()` throws, module initialization aborts, and the user is left staring at a blank white page.

This PR changes `fetchAuthSetup()` to pass `redirect: "manual"`. When the response comes back as `opaqueredirect` (i.e. Easy Auth wants to bounce us to the IdP), we `window.location.reload()` so the browser follows the redirect at the top level, where cross-origin navigation works normally and the login flow can complete. The returned promise is deliberately never resolved so the rest of the module does not try to initialize MSAL with a missing `AuthSetup` before the reload happens.

Manually verified against a login-enabled `azd` deploy: after clicking "Log out", the page cleanly redirects back through Entra and the app loads again, instead of white-screening with a CORS error in the console.

### Alternatives considered

- **Add `login.microsoftonline.com` to a CORS allowlist.** Not possible — the missing `Access-Control-Allow-Origin` header would have to be set by Microsoft's login endpoint, not by us. We can't make Microsoft add our origin to their responses.
- **Exclude `/auth_setup` from Easy Auth entirely** (via `excludedPaths` / `AllowAnonymous` in the Container Apps auth config in [`infra/main.bicep`](infra/main.bicep)). Arguably the "right" fix — the endpoint just returns public config, it doesn't need to be authenticated. But it's an infra-layer change that requires re-provisioning, and it only helps `/auth_setup`; any other fetch made after the Easy Auth cookie expires would still hit the same CORS wall.
- **Set `unauthenticatedClientAction: Return401`** on Easy Auth instead of `RedirectToLoginPage`. The fetch would get a real 401 and no cross-origin redirect, but it flips the behavior globally — a user landing on the app with an expired cookie would get a 401 body instead of being auto-redirected to login, so we'd have to add explicit login-triggering code anyway. Bigger behavior change for existing deployers.
- **Have the Quart `/auth_setup` route short-circuit before Easy Auth sees it.** Not possible — Easy Auth sits in front of the container, the app never sees the request.

The frontend `redirect: "manual"` + `window.location.reload()` fix is the smallest change, works for any Easy-Auth-fronted deploy without requiring re-provision, and doesn't alter the auth model.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

```
[ ] Yes
[x] No
```

## Type of change

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

- [x] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works — N/A, the bug only reproduces against a live Easy Auth deployment (verified manually).
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines — N/A for TS-only change; existing Python coverage unchanged.
- [x] I ran `ty check` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
