### PR TITLE
Upgrade msal-browser to 5.17 + msal-react to 5.5 bundled with required popup redirect-bridge scaffolding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,7 +255,26 @@ Use a dedicated azd env with login + access control enabled so the OBO code path
    * Ask a question that only the ACL'd document can answer (e.g. "What is included in the Northwind Standard plan?"). You should get an answer with citations only from that document.
    * Ask a question about a document that is NOT ACL'd to you (e.g. "What is included in the Northwind Health Plus plan?"). You should get "I don't know" / no citations. This confirms the OBO token was issued by `msal.ConfidentialClientApplication.acquire_token_on_behalf_of` and correctly passed to Azure AI Search as the access-control filter.
 
-7. **Optional: log out and reload.** Confirms Easy Auth logout works and re-auth kicks in cleanly.
+7. **Verify the popup login flow works in local dev.** The deployed Container Apps site uses Easy Auth redirect for login; the local dev server uses the MSAL popup flow, which is a completely different code path. Do NOT skip this — the msal-browser 5.x popup requires that `/redirect` return an empty page (proxied to the backend from vite), and previous upgrades have silently broken this.
+
+   ```shell
+   # Terminal 1: backend, pointed at the deployed login env's config
+   azd env select pf-ragchat-login
+   PORT=50505 ./app/start.sh
+
+   # Terminal 2: frontend dev server
+   cd app/frontend && BACKEND_PORT=50505 npm run dev
+   ```
+
+   Open `http://localhost:5173/`, click **Login**, complete the Entra popup, and confirm:
+   * The popup closes automatically after auth (does NOT leave the popup stuck on `http://localhost:5173/redirect#code=...`).
+   * The Login button in the top bar switches to your username.
+   * Ask a question and confirm ACL-filtered citations come back the same as in step 6.
+   * Click **Logout**, then **Login** again. The popup should complete cleanly a second time.
+
+   If the popup gets stuck on the redirect URL, check that `/redirect` is in the proxy list in `app/frontend/vite.config.ts` — it must be proxied to the backend so the popup lands on the empty page the backend serves rather than vite's SPA `index.html` fallback.
+
+8. **Optional: log out and reload on the deployed site.** Confirms Easy Auth logout works and re-auth kicks in cleanly.
 
 If any step fails, check container logs — `AuthError` from `app/backend/core/authentication.py` usually indicates the OBO token exchange or token validation broke.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,7 +272,7 @@ Use a dedicated azd env with login + access control enabled so the OBO code path
    * Ask a question and confirm ACL-filtered citations come back the same as in step 6.
    * Click **Logout**, then **Login** again. The popup should complete cleanly a second time.
 
-   If the popup gets stuck on the redirect URL, check that `/redirect` still serves the SPA (`index.html`) and that [app/frontend/src/index.tsx](app/frontend/src/index.tsx) runs `broadcastResponseToMainFrame()` from `@azure/msal-browser/redirect-bridge` before the app mounts. msal-browser 5.x uses a `BroadcastChannel` handshake and can no longer poll a truly blank redirect page.
+   If the popup gets stuck on the redirect URL, check that `/redirect` serves the dedicated [`app/frontend/redirect.html`](app/frontend/redirect.html) page (built from [`app/frontend/src/redirect.ts`](app/frontend/src/redirect.ts)) which runs `broadcastResponseToMainFrame()` from `@azure/msal-browser/redirect-bridge`. Per MSAL best practice this must be a minimal HTML page with ONLY the bridge script — no routing, no other application code. msal-browser 5.x uses a `BroadcastChannel` handshake and a truly blank redirect page no longer works.
 
 8. **Optional: log out and reload on the deployed site.** Confirms Easy Auth logout works and re-auth kicks in cleanly.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,10 +201,10 @@ The unit tests mock `msal` at the client level, so any change to `msal`, `@azure
 
 Use a dedicated azd env with login + access control enabled so the OBO code path is actually exercised.
 
-1. **Create the env and enable auth:**
+1. **Create the env and enable auth:** (any env name works — the steps below use `<AUTH_ENV_NAME>` as a placeholder)
 
    ```shell
-   azd env new pf-ragchat-login --subscription <SUB_ID> --location <REGION>
+   azd env new <AUTH_ENV_NAME> --subscription <SUB_ID> --location <REGION>
    azd env set AZURE_USE_AUTHENTICATION true
    azd env set AZURE_ENFORCE_ACCESS_CONTROL true
    azd env set AZURE_ENABLE_UNAUTHENTICATED_ACCESS false
@@ -219,7 +219,7 @@ Use a dedicated azd env with login + access control enabled so the OBO code path
 
    ```shell
    ./scripts/auth_init.sh   # creates the client + server Entra app registrations
-   azd up -e pf-ragchat-login
+   azd up -e <AUTH_ENV_NAME>
    ```
 
    `azd up` runs `auth_update.sh` as a postprovision hook to update the client app's redirect URIs.
@@ -259,7 +259,7 @@ Use a dedicated azd env with login + access control enabled so the OBO code path
 
    ```shell
    # Terminal 1: backend, pointed at the deployed login env's config
-   azd env select pf-ragchat-login
+   azd env select <AUTH_ENV_NAME>
    PORT=50505 ./app/start.sh
 
    # Terminal 2: frontend dev server

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,7 +272,7 @@ Use a dedicated azd env with login + access control enabled so the OBO code path
    * Ask a question and confirm ACL-filtered citations come back the same as in step 6.
    * Click **Logout**, then **Login** again. The popup should complete cleanly a second time.
 
-   If the popup gets stuck on the redirect URL, check that `/redirect` is in the proxy list in `app/frontend/vite.config.ts` — it must be proxied to the backend so the popup lands on the empty page the backend serves rather than vite's SPA `index.html` fallback.
+   If the popup gets stuck on the redirect URL, check that `/redirect` still serves the SPA (`index.html`) and that [app/frontend/src/index.tsx](app/frontend/src/index.tsx) runs `broadcastResponseToMainFrame()` from `@azure/msal-browser/redirect-bridge` before the app mounts. msal-browser 5.x uses a `BroadcastChannel` handshake and can no longer poll a truly blank redirect page.
 
 8. **Optional: log out and reload on the deployed site.** Confirms Easy Auth logout works and re-auth kicks in cleanly.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,7 +255,7 @@ Use a dedicated azd env with login + access control enabled so the OBO code path
    * Ask a question that only the ACL'd document can answer (e.g. "What is included in the Northwind Standard plan?"). You should get an answer with citations only from that document.
    * Ask a question about a document that is NOT ACL'd to you (e.g. "What is included in the Northwind Health Plus plan?"). You should get "I don't know" / no citations. This confirms the OBO token was issued by `msal.ConfidentialClientApplication.acquire_token_on_behalf_of` and correctly passed to Azure AI Search as the access-control filter.
 
-7. **Verify the popup login flow works in local dev.** The deployed Container Apps site uses Easy Auth redirect for login; the local dev server uses the MSAL popup flow, which is a completely different code path. Do NOT skip this — the msal-browser 5.x popup requires that `/redirect` return an empty page (proxied to the backend from vite), and previous upgrades have silently broken this.
+7. **Verify the popup login flow works in local dev.** The deployed Container Apps site uses Easy Auth redirect for login; the local dev server uses the MSAL popup flow, which is a completely different code path. Do NOT skip this — the msal-browser 5.x popup requires `/redirect` to serve the dedicated [`app/frontend/redirect.html`](app/frontend/redirect.html) bridge page (in dev the vite server owns it via a `/redirect` → `/redirect.html` middleware rewrite; in prod the Quart `/redirect` route serves the built `redirect.html` from `static/`), and previous upgrades have silently broken this.
 
    ```shell
    # Terminal 1: backend, pointed at the deployed login env's config

--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -117,14 +117,16 @@ async def index():
     return await bp.send_static_file("index.html")
 
 
-# The popup redirect URI must load the SPA so it can call
-# broadcastResponseToMainFrame() from @azure/msal-browser/redirect-bridge,
-# which post-messages the auth response back to the opener and closes the popup.
-# msal-browser 5.x removed the old URL-polling flow that a truly blank page relied on.
-# See https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/initialization.md#redirecturi-considerations for more information
+# Dedicated MSAL popup-redirect page. Per MSAL best practice this must be a
+# minimal page that only loads the redirect-bridge script — no routing, no
+# other application code — so we serve a separate redirect.html static asset
+# (not index.html). msal-browser 5.x uses a BroadcastChannel handshake and
+# the bridge script inside redirect.html posts the auth response back to the
+# opener window and closes the popup.
+# See https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/login-user.md#redirecturi-considerations
 @bp.route("/redirect")
 async def redirect():
-    return await bp.send_static_file("index.html")
+    return await bp.send_static_file("redirect.html")
 
 
 @bp.route("/favicon.ico")

--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -117,11 +117,14 @@ async def index():
     return await bp.send_static_file("index.html")
 
 
-# Empty page is recommended for login redirect to work.
+# The popup redirect URI must load the SPA so it can call
+# broadcastResponseToMainFrame() from @azure/msal-browser/redirect-bridge,
+# which post-messages the auth response back to the opener and closes the popup.
+# msal-browser 5.x removed the old URL-polling flow that a truly blank page relied on.
 # See https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/initialization.md#redirecturi-considerations for more information
 @bp.route("/redirect")
 async def redirect():
-    return ""
+    return await bp.send_static_file("index.html")
 
 
 @bp.route("/favicon.ico")

--- a/app/backend/core/authentication.py
+++ b/app/backend/core/authentication.py
@@ -85,7 +85,11 @@ class AuthenticationHelper:
                     "clientId": self.client_app_id,  # Client app id used for login
                     "authority": self.authority,  # Directory to use for login https://learn.microsoft.com/entra/identity-platform/msal-client-application-configuration#authority
                     "redirectUri": "/redirect",  # Points to window.location.origin. You must register this URI on Azure Portal/App Registration.
-                    "postLogoutRedirectUri": "/",  # Indicates the page to navigate after logout.
+                    # msal-browser's logoutPopup lands the popup on postLogoutRedirectUri, so it must
+                    # also point to the redirect-bridge page (/redirect) so it can broadcast the
+                    # logout response back to the opener and close the popup. mainWindowRedirectUri
+                    # (set per-call in the LoginButton) navigates the parent window to "/" after logout.
+                    "postLogoutRedirectUri": "/redirect",
                     "navigateToLoginRequestUrl": False,  # If "true", will navigate back to the original request location before processing the auth code response.
                 },
                 "cache": {

--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -8,8 +8,8 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@azure/msal-browser": "^4.16.0",
-        "@azure/msal-react": "^3.0.16",
+        "@azure/msal-browser": "^5.17.0",
+        "@azure/msal-react": "^5.5.2",
         "@fluentui/react-components": "^9.73.3",
         "@fluentui/react-icons": "^2.0.319",
         "@fluentui/react-table": "^9.19.14",
@@ -49,37 +49,37 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.16.0.tgz",
-      "integrity": "sha512-yF8gqyq7tVnYftnrWaNaxWpqhGQXoXpDfwBtL7UCGlIbDMQ1PUJF/T2xCL6NyDNHoO70qp1xU8GjjYTyNIefkw==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.17.0.tgz",
+      "integrity": "sha512-/yTnW2TCk9Mh+2b/NOaHAN+MryUNxzRTaJD/YtrqOA9bpBWfTXn/iyReRbaLrK/btBo3stEzLyEvuWp2NZ5DuA==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.9.0"
+        "@azure/msal-common": "16.11.1"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.9.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.9.0.tgz",
-      "integrity": "sha512-lbz/D+C9ixUG3hiZzBLjU79a0+5ZXCorjel3mwXluisKNH0/rOS/ajm8yi4yI9RP5Uc70CAcs9Ipd0051Oh/kA==",
+      "version": "16.11.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.1.tgz",
+      "integrity": "sha512-yPohvMwWLv1XnaWnIUyKUh8CvcVChCGqG/VluGwfGmaAfrZTNt5yQ+sIs462Sgw6+e2K83KGmMJ860p73ZSCrw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-react": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-3.0.16.tgz",
-      "integrity": "sha512-fIFc3z9UrHoOCG4rApNWMRr83DnQlo+CHfLSPNBQa4rndIkr+XYBpdYDqlzqtmikRf3A+CYNVOQ+lQX6jM0zdw==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-5.5.2.tgz",
+      "integrity": "sha512-gqLSay+1NfOjDUNL/A64myLhbPck/ne8Gw6O4Yb14Y/U/7AntnJs1Fzwyxt5AxOMnBkfzl9loDpBas2fugkwXw==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@azure/msal-browser": "^4.16.0",
-        "react": "^16.8.0 || ^17 || ^18 || ^19"
+        "@azure/msal-browser": "^5.17.0",
+        "react": "^16.8.0 || ^17 || ^18 || ^19.2.1"
       }
     },
     "node_modules/@babel/runtime": {

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -13,8 +13,8 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "@azure/msal-browser": "^4.16.0",
-    "@azure/msal-react": "^3.0.16",
+    "@azure/msal-browser": "^5.17.0",
+    "@azure/msal-react": "^5.5.2",
     "@fluentui/react-components": "^9.73.3",
     "@fluentui/react-icons": "^2.0.319",
     "@fluentui/react-table": "^9.19.14",

--- a/app/frontend/redirect.html
+++ b/app/frontend/redirect.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />

--- a/app/frontend/redirect.html
+++ b/app/frontend/redirect.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Signing in</title>
+    </head>
+    <body>
+        <p>Processing authentication&hellip;</p>
+        <script type="module" src="/src/redirect.ts"></script>
+    </body>
+</html>

--- a/app/frontend/src/api/api.ts
+++ b/app/frontend/src/api/api.ts
@@ -3,6 +3,25 @@ const BACKEND_URI = "";
 import { ChatAppResponse, ChatAppResponseOrError, ChatAppRequest, Config, SimpleAPIResponse, HistoryListApiResponse, HistoryApiResponse } from "./models";
 import { useLogin, getToken, isUsingAppServicesLogin } from "../authConfig";
 
+// Wrapper around fetch() that copes with Container Apps / App Service Easy Auth 302-ing to
+// login.microsoftonline.com when the Easy Auth session cookie is missing or expired.
+// A cross-origin 302 on a same-origin fetch is blocked by CORS ("No 'Access-Control-Allow-Origin'
+// header is present on the requested resource"), so instead we ask fetch for a manual redirect
+// and reload the top-level page when we see one — the browser can follow the cross-origin 302
+// on a top-level navigation and Easy Auth will complete the sign-in flow. Same pattern as
+// fetchAuthSetup() in authConfig.ts (see https://github.com/Azure-Samples/azure-search-openai-demo/issues/1780).
+export async function fetchWithAuthRedirect(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    const response = await fetch(input, { ...init, redirect: "manual" });
+    if (response.type === "opaqueredirect") {
+        window.location.reload();
+        // Never resolve — window.location.reload() is about to unload this page.
+        return new Promise<Response>(() => {
+            /* intentionally empty */
+        });
+    }
+    return response;
+}
+
 export async function getHeaders(idToken: string | undefined): Promise<Record<string, string>> {
     // If using login and not using app services, add the id token of the logged in account as the authorization
     if (useLogin && !isUsingAppServicesLogin) {
@@ -15,7 +34,7 @@ export async function getHeaders(idToken: string | undefined): Promise<Record<st
 }
 
 export async function configApi(): Promise<Config> {
-    const response = await fetch(`${BACKEND_URI}/config`, {
+    const response = await fetchWithAuthRedirect(`${BACKEND_URI}/config`, {
         method: "GET"
     });
 
@@ -28,7 +47,7 @@ export async function chatApi(request: ChatAppRequest, shouldStream: boolean, id
         url += "/stream";
     }
     const headers = await getHeaders(idToken);
-    return await fetch(url, {
+    return await fetchWithAuthRedirect(url, {
         method: "POST",
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify(request),
@@ -37,7 +56,7 @@ export async function chatApi(request: ChatAppRequest, shouldStream: boolean, id
 }
 
 export async function getSpeechApi(text: string): Promise<string | null> {
-    return await fetch("/speech", {
+    return await fetchWithAuthRedirect("/speech", {
         method: "POST",
         headers: {
             "Content-Type": "application/json"
@@ -67,7 +86,7 @@ export function getCitationFilePath(citation: string): string {
 }
 
 export async function uploadFileApi(request: FormData, idToken: string): Promise<SimpleAPIResponse> {
-    const response = await fetch("/upload", {
+    const response = await fetchWithAuthRedirect("/upload", {
         method: "POST",
         headers: await getHeaders(idToken),
         body: request
@@ -83,7 +102,7 @@ export async function uploadFileApi(request: FormData, idToken: string): Promise
 
 export async function deleteUploadedFileApi(filename: string, idToken: string): Promise<SimpleAPIResponse> {
     const headers = await getHeaders(idToken);
-    const response = await fetch("/delete_uploaded", {
+    const response = await fetchWithAuthRedirect("/delete_uploaded", {
         method: "POST",
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({ filename })
@@ -98,7 +117,7 @@ export async function deleteUploadedFileApi(filename: string, idToken: string): 
 }
 
 export async function listUploadedFilesApi(idToken: string): Promise<string[]> {
-    const response = await fetch(`/list_uploaded`, {
+    const response = await fetchWithAuthRedirect(`/list_uploaded`, {
         method: "GET",
         headers: await getHeaders(idToken)
     });
@@ -113,7 +132,7 @@ export async function listUploadedFilesApi(idToken: string): Promise<string[]> {
 
 export async function postChatHistoryApi(item: any, idToken: string): Promise<any> {
     const headers = await getHeaders(idToken);
-    const response = await fetch("/chat_history", {
+    const response = await fetchWithAuthRedirect("/chat_history", {
         method: "POST",
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify(item)
@@ -134,7 +153,7 @@ export async function getChatHistoryListApi(count: number, continuationToken: st
         url += `&continuationToken=${continuationToken}`;
     }
 
-    const response = await fetch(url.toString(), {
+    const response = await fetchWithAuthRedirect(url.toString(), {
         method: "GET",
         headers: { ...headers, "Content-Type": "application/json" }
     });
@@ -149,7 +168,7 @@ export async function getChatHistoryListApi(count: number, continuationToken: st
 
 export async function getChatHistoryApi(id: string, idToken: string): Promise<HistoryApiResponse> {
     const headers = await getHeaders(idToken);
-    const response = await fetch(`/chat_history/sessions/${id}`, {
+    const response = await fetchWithAuthRedirect(`/chat_history/sessions/${id}`, {
         method: "GET",
         headers: { ...headers, "Content-Type": "application/json" }
     });
@@ -164,7 +183,7 @@ export async function getChatHistoryApi(id: string, idToken: string): Promise<Hi
 
 export async function deleteChatHistoryApi(id: string, idToken: string): Promise<any> {
     const headers = await getHeaders(idToken);
-    const response = await fetch(`/chat_history/sessions/${id}`, {
+    const response = await fetchWithAuthRedirect(`/chat_history/sessions/${id}`, {
         method: "DELETE",
         headers: { ...headers, "Content-Type": "application/json" }
     });

--- a/app/frontend/src/authConfig.ts
+++ b/app/frontend/src/authConfig.ts
@@ -190,8 +190,12 @@ export const appServicesLogout = () => {
  */
 export const checkLoggedIn = async (client: IPublicClientApplication | undefined): Promise<boolean> => {
     if (client) {
-        const activeAccount = client.getActiveAccount();
-        if (activeAccount) {
+        // getActiveAccount() only returns an account after setActiveAccount() has been called
+        // (which we do in the LOGIN_SUCCESS handler in index.tsx). getAllAccounts() is populated
+        // as soon as MSAL processes the token response, so it's the correct check for "logged in"
+        // regardless of which msal-browser event fired first. See msal-react's own useIsAuthenticated
+        // hook, which uses accounts.length > 0 for the same reason.
+        if (client.getActiveAccount() || client.getAllAccounts().length > 0) {
             return true;
         }
     }
@@ -232,9 +236,13 @@ export const getToken = async (client: IPublicClientApplication): Promise<string
  * @returns {Promise<string | null>} The username of the active account, or null if no username is found.
  */
 export const getUsername = async (client: IPublicClientApplication): Promise<string | null> => {
-    const activeAccount = client.getActiveAccount();
-    if (activeAccount) {
-        return activeAccount.username;
+    // Prefer the active account if one has been set; otherwise fall back to the first cached
+    // account. Immediately after a popup login MSAL populates getAllAccounts() before our
+    // LOGIN_SUCCESS handler runs setActiveAccount(), so a strict getActiveAccount() check
+    // returns null and the UI would appear stale until the user reloads.
+    const account = client.getActiveAccount() ?? client.getAllAccounts()[0];
+    if (account) {
+        return account.username;
     }
 
     const appServicesToken = await getAppServicesToken();
@@ -252,9 +260,10 @@ export const getUsername = async (client: IPublicClientApplication): Promise<str
  * @returns {Promise<Record<string, unknown> | undefined>} A promise that resolves to the token claims of the active account, the user claims from the app services login token, or undefined if no claims are found.
  */
 export const getTokenClaims = async (client: IPublicClientApplication): Promise<Record<string, unknown> | undefined> => {
-    const activeAccount = client.getActiveAccount();
-    if (activeAccount) {
-        return activeAccount.idTokenClaims;
+    // Same active-vs-all-accounts fallback as getUsername — see comment there.
+    const account = client.getActiveAccount() ?? client.getAllAccounts()[0];
+    if (account) {
+        return account.idTokenClaims;
     }
 
     const appServicesToken = await getAppServicesToken();

--- a/app/frontend/src/authConfig.ts
+++ b/app/frontend/src/authConfig.ts
@@ -111,8 +111,15 @@ export const getRedirectUri = () => {
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this#global_context
 declare global {
     var cachedAppServicesToken: AppServicesToken | null;
+    // Sticky "no Easy Auth here" flag. When /.auth/me returns 404 (or otherwise
+    // yields no token) once, remember it so downstream code paths that fall back
+    // to getAppServicesToken() (checkLoggedIn, getUsername, getTokenClaims) do
+    // not keep re-issuing 404s on every render / MSAL event tick. This is a
+    // deployment-time property, not something that flips at runtime.
+    var appServicesAuthUnavailable: boolean;
 }
 globalThis.cachedAppServicesToken = null;
+globalThis.appServicesAuthUnavailable = false;
 
 /**
  * Retrieves an access token if the user is logged in using app services authentication.
@@ -130,6 +137,10 @@ const getAppServicesToken = (): Promise<AppServicesToken | null> => {
 
     if (globalThis.cachedAppServicesToken && checkNotExpired(globalThis.cachedAppServicesToken)) {
         return Promise.resolve(globalThis.cachedAppServicesToken);
+    }
+
+    if (globalThis.appServicesAuthUnavailable) {
+        return Promise.resolve(null);
     }
 
     const getAppServicesTokenFromMe: () => Promise<AppServicesToken | null> = () => {
@@ -152,6 +163,9 @@ const getAppServicesToken = (): Promise<AppServicesToken | null> => {
                 });
             }
 
+            // Endpoint isn't there (404 in local dev, or Easy Auth not configured).
+            // Latch this so we never retry.
+            globalThis.appServicesAuthUnavailable = true;
             return null;
         });
     };

--- a/app/frontend/src/authConfig.ts
+++ b/app/frontend/src/authConfig.ts
@@ -172,9 +172,13 @@ const getAppServicesToken = (): Promise<AppServicesToken | null> => {
                 });
             }
 
-            // Endpoint isn't there (404 in local dev, or Easy Auth not configured).
-            // Latch this so we never retry.
-            globalThis.appServicesAuthUnavailable = true;
+            // Only latch on 404 — that's the deploy-time signal that Easy Auth isn't
+            // configured (or we're in local dev with no /.auth/me at all). Other statuses
+            // like 401 (session expired), 403, or transient 5xx can recover on the next
+            // call, so leave the flag alone for those.
+            if (r.status === 404) {
+                globalThis.appServicesAuthUnavailable = true;
+            }
             return null;
         });
     };

--- a/app/frontend/src/authConfig.ts
+++ b/app/frontend/src/authConfig.ts
@@ -1,6 +1,15 @@
 // Refactored from https://github.com/Azure-Samples/ms-identity-javascript-react-tutorial/blob/main/1-Authentication/1-sign-in/SPA/src/authConfig.js
 
-import { IPublicClientApplication } from "@azure/msal-browser";
+import { AccountInfo, IPublicClientApplication } from "@azure/msal-browser";
+
+// getActiveAccount() only returns an account after setActiveAccount() has been called
+// (which we do in the LOGIN_SUCCESS handler in index.tsx). Immediately after a popup login,
+// msal-browser 5.x fires ACQUIRE_TOKEN_SUCCESS *before* LOGIN_SUCCESS, so getActiveAccount()
+// briefly returns null while getAllAccounts() is already populated. Falling back to the first
+// cached account matches what msal-react's own useIsAuthenticated hook does and avoids stale UI.
+export const getActiveOrFirstAccount = (client: IPublicClientApplication): AccountInfo | null => {
+    return client.getActiveAccount() ?? client.getAllAccounts()[0] ?? null;
+};
 
 const appServicesAuthTokenUrl = ".auth/me";
 const appServicesAuthTokenRefreshUrl = ".auth/refresh";
@@ -203,15 +212,8 @@ export const appServicesLogout = () => {
  * @returns {Promise<boolean>} A promise that resolves to true if the user is logged in, false otherwise.
  */
 export const checkLoggedIn = async (client: IPublicClientApplication | undefined): Promise<boolean> => {
-    if (client) {
-        // getActiveAccount() only returns an account after setActiveAccount() has been called
-        // (which we do in the LOGIN_SUCCESS handler in index.tsx). getAllAccounts() is populated
-        // as soon as MSAL processes the token response, so it's the correct check for "logged in"
-        // regardless of which msal-browser event fired first. See msal-react's own useIsAuthenticated
-        // hook, which uses accounts.length > 0 for the same reason.
-        if (client.getActiveAccount() || client.getAllAccounts().length > 0) {
-            return true;
-        }
+    if (client && getActiveOrFirstAccount(client)) {
+        return true;
     }
 
     const appServicesToken = await getAppServicesToken();
@@ -250,11 +252,7 @@ export const getToken = async (client: IPublicClientApplication): Promise<string
  * @returns {Promise<string | null>} The username of the active account, or null if no username is found.
  */
 export const getUsername = async (client: IPublicClientApplication): Promise<string | null> => {
-    // Prefer the active account if one has been set; otherwise fall back to the first cached
-    // account. Immediately after a popup login MSAL populates getAllAccounts() before our
-    // LOGIN_SUCCESS handler runs setActiveAccount(), so a strict getActiveAccount() check
-    // returns null and the UI would appear stale until the user reloads.
-    const account = client.getActiveAccount() ?? client.getAllAccounts()[0];
+    const account = getActiveOrFirstAccount(client);
     if (account) {
         return account.username;
     }
@@ -274,8 +272,7 @@ export const getUsername = async (client: IPublicClientApplication): Promise<str
  * @returns {Promise<Record<string, unknown> | undefined>} A promise that resolves to the token claims of the active account, the user claims from the app services login token, or undefined if no claims are found.
  */
 export const getTokenClaims = async (client: IPublicClientApplication): Promise<Record<string, unknown> | undefined> => {
-    // Same active-vs-all-accounts fallback as getUsername — see comment there.
-    const account = client.getActiveAccount() ?? client.getAllAccounts()[0];
+    const account = getActiveOrFirstAccount(client);
     if (account) {
         return account.idTokenClaims;
     }

--- a/app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsx
+++ b/app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsx
@@ -3,7 +3,7 @@ import { Tab, TabList, SelectTabData, SelectTabEvent } from "@fluentui/react-com
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { ChatAppResponse, getHeaders } from "../../api";
+import { ChatAppResponse, fetchWithAuthRedirect, getHeaders } from "../../api";
 import { getToken, useLogin } from "../../authConfig";
 import { MarkdownViewer } from "../MarkdownViewer";
 import { SupportingContent } from "../SupportingContent";
@@ -43,7 +43,7 @@ export const AnalysisPanel = ({ answer, activeTab, activeCitation, citationHeigh
             // Get hash from the URL as it may contain #page=N
             // which helps browser PDF renderer jump to correct page N
             const originalHash = activeCitation.indexOf("#") ? activeCitation.split("#")[1] : "";
-            const response = await fetch(activeCitation, {
+            const response = await fetchWithAuthRedirect(activeCitation, {
                 method: "GET",
                 headers: await getHeaders(token)
             });

--- a/app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsx
+++ b/app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsx
@@ -42,7 +42,7 @@ export const AnalysisPanel = ({ answer, activeTab, activeCitation, citationHeigh
         if (activeCitation) {
             // Get hash from the URL as it may contain #page=N
             // which helps browser PDF renderer jump to correct page N
-            const originalHash = activeCitation.indexOf("#") ? activeCitation.split("#")[1] : "";
+            const originalHash = activeCitation.includes("#") ? activeCitation.split("#")[1] : "";
             const response = await fetchWithAuthRedirect(activeCitation, {
                 method: "GET",
                 headers: await getHeaders(token)

--- a/app/frontend/src/components/LoginButton/LoginButton.tsx
+++ b/app/frontend/src/components/LoginButton/LoginButton.tsx
@@ -10,7 +10,6 @@ import { LoginContext } from "../../loginContext";
 export const LoginButton = () => {
     const { instance } = useMsal();
     const { loggedIn, setLoggedIn } = useContext(LoginContext);
-    const activeAccount = instance.getActiveAccount();
     const [username, setUsername] = useState("");
     const { t } = useTranslation();
 
@@ -42,11 +41,16 @@ export const LoginButton = () => {
             });
     };
     const handleLogoutPopup = () => {
-        if (activeAccount) {
+        // getActiveAccount() can be null between an MSAL token event and our setActiveAccount() handler
+        // (same msal-browser 5.x race that checkLoggedIn/getUsername already handle). Fall back to the
+        // first cached account so we always go down the MSAL logoutPopup path instead of accidentally
+        // triggering appServicesLogout() and navigating the top window to /.auth/logout.
+        const account = instance.getActiveAccount() ?? instance.getAllAccounts()[0];
+        if (account) {
             instance
                 .logoutPopup({
                     mainWindowRedirectUri: "/", // redirects the top level app after logout
-                    account: instance.getActiveAccount()
+                    account
                 })
                 .catch(error => console.log(error))
                 .then(async () => {

--- a/app/frontend/src/components/LoginButton/LoginButton.tsx
+++ b/app/frontend/src/components/LoginButton/LoginButton.tsx
@@ -14,13 +14,15 @@ export const LoginButton = () => {
     const [username, setUsername] = useState("");
     const { t } = useTranslation();
 
+    // Re-fetch the username whenever loggedIn flips (LayoutWrapper drives loggedIn from MSAL events),
+    // so the button correctly shows the signed-in user after a popup login/logout without a page reload.
     useEffect(() => {
         const fetchUsername = async () => {
             setUsername((await getUsername(instance)) ?? "");
         };
 
         fetchUsername();
-    }, []);
+    }, [instance, loggedIn]);
 
     const handleLoginPopup = () => {
         /**

--- a/app/frontend/src/components/LoginButton/LoginButton.tsx
+++ b/app/frontend/src/components/LoginButton/LoginButton.tsx
@@ -3,7 +3,7 @@ import { useMsal } from "@azure/msal-react";
 import { useTranslation } from "react-i18next";
 
 import styles from "./LoginButton.module.css";
-import { getRedirectUri, loginRequest, appServicesLogout, getUsername, checkLoggedIn } from "../../authConfig";
+import { getRedirectUri, loginRequest, appServicesLogout, getActiveOrFirstAccount, getUsername, checkLoggedIn } from "../../authConfig";
 import { useState, useEffect, useContext } from "react";
 import { LoginContext } from "../../loginContext";
 
@@ -41,11 +41,10 @@ export const LoginButton = () => {
             });
     };
     const handleLogoutPopup = () => {
-        // getActiveAccount() can be null between an MSAL token event and our setActiveAccount() handler
-        // (same msal-browser 5.x race that checkLoggedIn/getUsername already handle). Fall back to the
-        // first cached account so we always go down the MSAL logoutPopup path instead of accidentally
-        // triggering appServicesLogout() and navigating the top window to /.auth/logout.
-        const account = instance.getActiveAccount() ?? instance.getAllAccounts()[0];
+        // Fall back to the first cached account if there is no active account, so we always take
+        // the MSAL logoutPopup path instead of accidentally triggering appServicesLogout() and
+        // navigating the top window to /.auth/logout.
+        const account = getActiveOrFirstAccount(instance);
         if (account) {
             instance
                 .logoutPopup({

--- a/app/frontend/src/components/MarkdownViewer/MarkdownViewer.tsx
+++ b/app/frontend/src/components/MarkdownViewer/MarkdownViewer.tsx
@@ -6,6 +6,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import styles from "./MarkdownViewer.module.css";
+import { fetchWithAuthRedirect } from "../../api";
 
 interface MarkdownViewerProps {
     src: string;
@@ -29,7 +30,7 @@ export const MarkdownViewer: React.FC<MarkdownViewerProps> = ({ src }) => {
     useEffect(() => {
         const fetchMarkdown = async () => {
             try {
-                const response = await fetch(src);
+                const response = await fetchWithAuthRedirect(src);
 
                 if (!response.ok) {
                     throw new Error("Failed loading markdown file.");

--- a/app/frontend/src/components/TokenClaimsDisplay/TokenClaimsDisplay.tsx
+++ b/app/frontend/src/components/TokenClaimsDisplay/TokenClaimsDisplay.tsx
@@ -20,7 +20,6 @@ type Claim = {
 
 export const TokenClaimsDisplay = () => {
     const { instance } = useMsal();
-    const activeAccount = instance.getActiveAccount();
     const [claims, setClaims] = useState<Record<string, unknown> | undefined>(undefined);
 
     useEffect(() => {

--- a/app/frontend/src/index.tsx
+++ b/app/frontend/src/index.tsx
@@ -5,7 +5,6 @@ import { I18nextProvider } from "react-i18next";
 import { HelmetProvider } from "react-helmet-async";
 import { MsalProvider } from "@azure/msal-react";
 import { AuthenticationResult, EventType, PublicClientApplication } from "@azure/msal-browser";
-import { broadcastResponseToMainFrame } from "@azure/msal-browser/redirect-bridge";
 
 import "./index.css";
 
@@ -13,29 +12,6 @@ import Chat from "./pages/chat/Chat";
 import LayoutWrapper from "./layoutWrapper";
 import i18next from "./i18n/config";
 import { msalConfig, useLogin } from "./authConfig";
-
-// If this window was opened by MSAL as a login/logout popup and now carries an auth
-// response, hand it back to the opener via BroadcastChannel and close the popup.
-// msal-browser 5.x uses BroadcastChannel bridging instead of URL polling, so a truly
-// blank redirect page no longer works — the redirect URI must run this bridge script.
-// See https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/initialization.md#redirecturi-considerations
-if (
-    useLogin &&
-    window.opener &&
-    window.opener !== window &&
-    (window.location.hash.includes("code=") ||
-        window.location.hash.includes("error=") ||
-        window.location.search.includes("code=") ||
-        window.location.search.includes("error="))
-) {
-    broadcastResponseToMainFrame().catch(e => {
-        // eslint-disable-next-line no-console
-        console.error("MSAL popup redirect bridge failed", e);
-    });
-    // broadcastResponseToMainFrame calls window.close(); stop here so the SPA
-    // does not mount in the popup and interfere with the handshake.
-    throw new Error("stop-popup-bootstrap");
-}
 
 const router = createHashRouter([
     {

--- a/app/frontend/src/index.tsx
+++ b/app/frontend/src/index.tsx
@@ -5,6 +5,7 @@ import { I18nextProvider } from "react-i18next";
 import { HelmetProvider } from "react-helmet-async";
 import { MsalProvider } from "@azure/msal-react";
 import { AuthenticationResult, EventType, PublicClientApplication } from "@azure/msal-browser";
+import { broadcastResponseToMainFrame } from "@azure/msal-browser/redirect-bridge";
 
 import "./index.css";
 
@@ -12,6 +13,29 @@ import Chat from "./pages/chat/Chat";
 import LayoutWrapper from "./layoutWrapper";
 import i18next from "./i18n/config";
 import { msalConfig, useLogin } from "./authConfig";
+
+// If this window was opened by MSAL as a login/logout popup and now carries an auth
+// response, hand it back to the opener via BroadcastChannel and close the popup.
+// msal-browser 5.x uses BroadcastChannel bridging instead of URL polling, so a truly
+// blank redirect page no longer works — the redirect URI must run this bridge script.
+// See https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/initialization.md#redirecturi-considerations
+if (
+    useLogin &&
+    window.opener &&
+    window.opener !== window &&
+    (window.location.hash.includes("code=") ||
+        window.location.hash.includes("error=") ||
+        window.location.search.includes("code=") ||
+        window.location.search.includes("error="))
+) {
+    broadcastResponseToMainFrame().catch(e => {
+        // eslint-disable-next-line no-console
+        console.error("MSAL popup redirect bridge failed", e);
+    });
+    // broadcastResponseToMainFrame calls window.close(); stop here so the SPA
+    // does not mount in the popup and interfere with the handshake.
+    throw new Error("stop-popup-bootstrap");
+}
 
 const router = createHashRouter([
     {

--- a/app/frontend/src/layoutWrapper.tsx
+++ b/app/frontend/src/layoutWrapper.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { FluentProvider, webLightTheme } from "@fluentui/react-components";
 import { useMsal } from "@azure/msal-react";
+import { EventType } from "@azure/msal-browser";
 import { useLogin, checkLoggedIn } from "./authConfig";
 import { LoginContext } from "./loginContext";
 import Layout from "./pages/layout/Layout";
@@ -13,15 +14,41 @@ const LayoutWrapper = () => {
         const mounted = useRef<boolean>(true);
         useEffect(() => {
             mounted.current = true;
-            checkLoggedIn(instance)
-                .then(isLoggedIn => {
-                    if (mounted.current) setLoggedIn(isLoggedIn);
-                })
-                .catch(e => {
-                    console.error("checkLoggedIn failed", e);
-                });
+
+            const refresh = () => {
+                checkLoggedIn(instance)
+                    .then(isLoggedIn => {
+                        if (mounted.current) setLoggedIn(isLoggedIn);
+                    })
+                    .catch(e => {
+                        console.error("checkLoggedIn failed", e);
+                    });
+            };
+
+            // Initial check on mount (may already be signed in from a prior session).
+            refresh();
+
+            // Keep loggedIn in sync with MSAL. Both LOGIN_SUCCESS/LOGOUT_SUCCESS and
+            // ACTIVE_ACCOUNT_CHANGED are needed because getActiveAccount() may still
+            // return null right after LOGIN_SUCCESS fires — msal-react docs recommend
+            // subscribing to ACTIVE_ACCOUNT_CHANGED for this reason.
+            // https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-react/docs/hooks.md#usemsal-hook
+            const callbackId = instance.addEventCallback(event => {
+                if (
+                    event.eventType === EventType.LOGIN_SUCCESS ||
+                    event.eventType === EventType.LOGOUT_SUCCESS ||
+                    event.eventType === EventType.ACTIVE_ACCOUNT_CHANGED ||
+                    event.eventType === EventType.ACQUIRE_TOKEN_SUCCESS
+                ) {
+                    refresh();
+                }
+            });
+
             return () => {
                 mounted.current = false;
+                if (callbackId) {
+                    instance.removeEventCallback(callbackId);
+                }
             };
         }, [instance]);
 

--- a/app/frontend/src/redirect.ts
+++ b/app/frontend/src/redirect.ts
@@ -1,0 +1,10 @@
+// Dedicated MSAL redirect-bridge entry point.
+// This file is intentionally minimal: per MSAL docs the popup redirect page must
+// contain ONLY the bridge script — no routing, no app code.
+// See https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/login-user.md#redirecturi-considerations
+import { broadcastResponseToMainFrame } from "@azure/msal-browser/redirect-bridge";
+
+broadcastResponseToMainFrame().catch(err => {
+    // eslint-disable-next-line no-console
+    console.error("MSAL redirect bridge failed", err);
+});

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -34,7 +34,6 @@ export default defineConfig(() => {
             proxy: {
                 "/content/": backendUrl,
                 "/auth_setup": backendUrl,
-                "/redirect": backendUrl,
                 "/.auth/me": backendUrl,
                 "/chat": backendUrl,
                 "/speech": backendUrl,

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -1,13 +1,29 @@
 /// <reference types="node" />
-import { defineConfig } from "vite";
+import { resolve } from "node:path";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
+
+// Vite serves redirect.html at "/redirect.html", but the MSAL redirect URI is "/redirect"
+// (matching the deployed backend route). This tiny middleware rewrites "/redirect" to
+// "/redirect.html" during dev so the popup handshake works locally.
+const redirectAlias: Plugin = {
+    name: "redirect-html-alias",
+    configureServer(server) {
+        server.middlewares.use((req, _res, next) => {
+            if (req.url === "/redirect" || req.url?.startsWith("/redirect?")) {
+                req.url = "/redirect.html" + req.url.slice("/redirect".length);
+            }
+            next();
+        });
+    }
+};
 
 // https://vitejs.dev/config/
 export default defineConfig(() => {
     const backendPort = process.env.BACKEND_PORT || "50505";
     const backendUrl = `http://localhost:${backendPort}`;
     return {
-        plugins: [react()],
+        plugins: [react(), redirectAlias],
         resolve: {
             preserveSymlinks: true
         },
@@ -16,8 +32,20 @@ export default defineConfig(() => {
             emptyOutDir: true,
             sourcemap: true,
             rollupOptions: {
+                input: {
+                    main: resolve(__dirname, "index.html"),
+                    // Dedicated MSAL popup-redirect page — contains only the bridge script.
+                    // See https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/login-user.md#redirecturi-considerations
+                    redirect: resolve(__dirname, "redirect.html")
+                },
                 output: {
                     manualChunks: id => {
+                        // Keep the MSAL redirect-bridge chunk isolated so that the
+                        // dedicated redirect.html popup entry does not pull in React,
+                        // Fluent UI, or the rest of the SPA vendor bundle.
+                        if (id.includes("@azure/msal-browser") || id.includes("@azure/msal-common")) {
+                            return "msal";
+                        }
                         if (id.includes("@fluentui/react-icons")) {
                             return "fluentui-icons";
                         } else if (id.includes("@fluentui/react")) {

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -34,6 +34,7 @@ export default defineConfig(() => {
             proxy: {
                 "/content/": backendUrl,
                 "/auth_setup": backendUrl,
+                "/redirect": backendUrl,
                 "/.auth/me": backendUrl,
                 "/chat": backendUrl,
                 "/speech": backendUrl,

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -3,9 +3,16 @@ import { resolve } from "node:path";
 import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 
-// Vite serves redirect.html at "/redirect.html", but the MSAL redirect URI is "/redirect"
-// (matching the deployed backend route). This tiny middleware rewrites "/redirect" to
-// "/redirect.html" during dev so the popup handshake works locally.
+// MSAL is configured with redirectUri = "/redirect", matching the Quart /redirect route
+// in production (which send_static_file's the built redirect.html). In vite dev, redirect.html
+// is a rollup MPA entry that vite serves at its filename "/redirect.html" with live TS
+// transformation of /src/redirect.ts. This middleware rewrites "/redirect" -> "/redirect.html"
+// so the popup URL matches production without requiring a build step.
+//
+// We can't just proxy "/redirect" to the Quart backend because the built redirect.html
+// references bundled assets under "/assets/" (e.g. /assets/msal-*.js), and vite dev on this
+// origin doesn't own the /assets/ prefix. Letting vite serve the entry keeps the popup
+// running against transformed source and avoids a second server serving that URL space.
 const redirectAlias: Plugin = {
     name: "redirect-html-alias",
     configureServer(server) {

--- a/tests/snapshots/test_authenticationhelper/test_auth_setup/result.json
+++ b/tests/snapshots/test_authenticationhelper/test_auth_setup/result.json
@@ -7,7 +7,7 @@
             "clientId": "CLIENT_APP",
             "authority": "https://login.microsoftonline.com/TENANT_ID",
             "redirectUri": "/redirect",
-            "postLogoutRedirectUri": "/",
+            "postLogoutRedirectUri": "/redirect",
             "navigateToLoginRequestUrl": false
         },
         "cache": {

--- a/tests/snapshots/test_authenticationhelper/test_auth_setup_required_access_control/result.json
+++ b/tests/snapshots/test_authenticationhelper/test_auth_setup_required_access_control/result.json
@@ -7,7 +7,7 @@
             "clientId": "CLIENT_APP",
             "authority": "https://login.microsoftonline.com/TENANT_ID",
             "redirectUri": "/redirect",
-            "postLogoutRedirectUri": "/",
+            "postLogoutRedirectUri": "/redirect",
             "navigateToLoginRequestUrl": false
         },
         "cache": {

--- a/tests/snapshots/test_authenticationhelper/test_auth_setup_required_access_control_and_unauthenticated_access/result.json
+++ b/tests/snapshots/test_authenticationhelper/test_auth_setup_required_access_control_and_unauthenticated_access/result.json
@@ -7,7 +7,7 @@
             "clientId": "CLIENT_APP",
             "authority": "https://login.microsoftonline.com/TENANT_ID",
             "redirectUri": "/redirect",
-            "postLogoutRedirectUri": "/",
+            "postLogoutRedirectUri": "/redirect",
             "navigateToLoginRequestUrl": false
         },
         "cache": {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -79,8 +79,9 @@ async def test_index(client):
 async def test_redirect(client):
     response = await client.get("/redirect")
     assert response.status_code == 200
-    # /redirect serves the SPA (index.html) so it can run the msal-browser
-    # redirect-bridge script that posts the auth response back to the opener.
+    # /redirect serves the dedicated redirect.html bridge page, which runs the
+    # msal-browser redirect-bridge script that posts the auth response back to
+    # the opener via BroadcastChannel.
     assert response.content_type.startswith("text/html")
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -79,7 +79,9 @@ async def test_index(client):
 async def test_redirect(client):
     response = await client.get("/redirect")
     assert response.status_code == 200
-    assert (await response.get_data()) == b""
+    # /redirect serves the SPA (index.html) so it can run the msal-browser
+    # redirect-bridge script that posts the auth response back to the opener.
+    assert response.content_type.startswith("text/html")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Purpose

Bundles the msal-browser 5.x upgrade with all the frontend work required to make it actually work.

msal-browser 5.x replaced the classic "parent polls `popup.location.href`" popup handshake with a `BroadcastChannel` bridge that requires a dedicated redirect-bridge page. #3139 originally landed the upgrade on its own, which broke local-dev popup login (and would have broken any deploy that actually exercises the popup path). #3149 reverted that upgrade so main is clean; this PR re-applies the upgrade together with the full set of code changes needed to run it correctly.

## What's in this PR

### Package upgrades (re-applied from #3139)
- `@azure/msal-browser` `^4.16.0` → `^5.17.0`
- `@azure/msal-react` `^3.0.16` → `^5.5.2`

### Dedicated MSAL redirect-bridge page (per [MSAL 5.x docs](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/login-user.md#redirecturi-considerations))
- **[`app/frontend/redirect.html`](app/frontend/redirect.html)** — minimal HTML page (`<title>Signing in</title>`) with a single module script and nothing else.
- **[`app/frontend/src/redirect.ts`](app/frontend/src/redirect.ts)** — imports and calls `broadcastResponseToMainFrame()` from `@azure/msal-browser/redirect-bridge`.
- **[`app/frontend/vite.config.ts`](app/frontend/vite.config.ts)** — adds `redirect.html` as a second rollup entry, isolates `@azure/msal-browser` / `@azure/msal-common` into a dedicated `msal` chunk so the popup entry doesn't pull in React / Fluent UI / vendor, and rewrites `/redirect` → `/redirect.html` in the dev server so the popup redirect URI matches production without a trailing `.html`.
- **[`app/backend/app.py`](app/backend/app.py)** — `/redirect` now serves `redirect.html` (not `index.html` or an empty response).

Popup entry-point download drops from the full ~1.9 MB SPA bundle to `redirect.js` (195 bytes) + `msal.js` (235 KB, gzip 59 KB).

### Account-lookup race fixes
- **[`app/frontend/src/authConfig.ts`](app/frontend/src/authConfig.ts)** — `checkLoggedIn` / `getUsername` / `getTokenClaims` now fall back to `getAllAccounts()[0]` when there is no active account. `getActiveAccount()` returns `null` between `ACQUIRE_TOKEN_SUCCESS` (which msal-browser 5.x fires first) and the `setActiveAccount()` call in our `LOGIN_SUCCESS` handler, which caused the button to stay showing "Login" even after a successful popup login. `msal-react`'s own [`useIsAuthenticated`](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-react/dist/hooks/useIsAuthenticated.js) uses `accounts.length > 0` for the same reason.
- **[`app/frontend/src/components/LoginButton/LoginButton.tsx`](app/frontend/src/components/LoginButton/LoginButton.tsx)** — the username `useEffect` depended on `[]`, so it never refreshed after login. Now depends on `[instance, loggedIn]`. `handleLogoutPopup` also uses the same `getActiveAccount() ?? getAllAccounts()[0]` fallback so we always go down the MSAL `logoutPopup` path instead of accidentally triggering `appServicesLogout()` and navigating the top window to `/.auth/logout`.

### Login state driven by MSAL events (msal-react best practice)
- **[`app/frontend/src/layoutWrapper.tsx`](app/frontend/src/layoutWrapper.tsx)** — subscribe to `LOGIN_SUCCESS` / `LOGOUT_SUCCESS` / `ACTIVE_ACCOUNT_CHANGED` / `ACQUIRE_TOKEN_SUCCESS` and re-run `checkLoggedIn` on each, per the msal-react [hooks docs](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-react/docs/hooks.md#usemsal-hook) note about `getActiveAccount()` racing `setActiveAccount()`.

### Logout popup fix
- **[`app/backend/core/authentication.py`](app/backend/core/authentication.py)** — `postLogoutRedirectUri` moved from `/` (SPA root) to `/redirect` so the popup lands on the bridge page and closes itself, instead of showing the full app inside the popup. `mainWindowRedirectUri: "/"` passed per-call in `LoginButton.tsx` already handles navigating the parent window to `/` after logout. `/redirect` is already registered as an SPA redirect URI in [`scripts/auth_update.py`](scripts/auth_update.py), so no Entra app registration change is needed.

### Handle Easy Auth 302 to Entra on API fetches
- **[`app/frontend/src/api/api.ts`](app/frontend/src/api/api.ts)** — new `fetchWithAuthRedirect()` helper wraps every API call with `redirect: "manual"` and reloads the page on `response.type === "opaqueredirect"`. When the Container Apps / App Service Easy Auth session cookie is missing or expired (e.g. after a new revision is rolled out), Easy Auth returns a 302 to `login.microsoftonline.com` for every request; a same-origin fetch cannot follow that cross-origin redirect and fails with a CORS error. Reloading the top-level page lets the browser follow the 302 and lets Easy Auth complete sign-in. Same pattern that `fetchAuthSetup()` already uses for `/auth_setup` (#1780). Also applied to citation fetches in [`AnalysisPanel.tsx`](app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsx) and [`MarkdownViewer.tsx`](app/frontend/src/components/MarkdownViewer/MarkdownViewer.tsx).

### Quiet the `/.auth/me` 404 storm in local dev
- **[`app/frontend/src/authConfig.ts`](app/frontend/src/authConfig.ts)** — latch a `globalThis.appServicesAuthUnavailable` flag on the first 404 from `/.auth/me` (Easy Auth availability is a deploy-time property, not a runtime one) and short-circuit further `getAppServicesToken()` calls to `Promise.resolve(null)`. Every LayoutWrapper event now results in **one** cheap resolved-null instead of ~4 red 404s per interaction.

### Docs update
- **[`AGENTS.md`](AGENTS.md)** — expand the auth manual test plan with an explicit local-dev popup step that spins up both the backend and vite dev server and confirms the popup closes cleanly, plus a debug hint pointing at `redirect.html` + `redirect.ts`. Previous msal upgrades silently broke this because it wasn't exercised in QA.

## Testing

- `python -m pytest tests/test_app.py::test_redirect tests/test_authenticationhelper.py` — passes.
- `npm run build` — clean; redirect-bridge sub-path import bundles fine.
- Full auth manual test plan from AGENTS.md verified against a deployed login-enabled azd env (`pf-ragchat-login`): popup login closes cleanly, LoginButton flips to username, ACL'd/non-ACL'd citation checks return expected results, logout popup closes cleanly and parent window navigates to `/`, and the Easy Auth 302-on-API-fetch case triggers a top-level reload that completes Entra sign-in.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

Deployed behavior unchanged (Container Apps Easy Auth still handles the deployed login path). Local dev popup flow that was broken between #3139 and this PR is fixed. Stale-Easy-Auth-session case that previously threw a CORS error now recovers via a page reload.

## Does this require changes to learn.microsoft.com docs?

```
[ ] Yes
[x] No
```

## Type of change

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: bundles the msal-browser 5.x package upgrade with the code changes needed to make it work
```

## Code quality checklist

- [x] The current tests all pass (`python -m pytest`).
- [x] I added tests that prove my fix is effective or that my feature works — updated `test_redirect` assertion; other paths need a live Entra deploy (documented in the AGENTS.md manual test plan step 7).
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines.
- [x] I ran `ty check` to check for type errors.
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
