### PR TITLE
Revert "chore(deps): upgrade @azure/msal-browser to 5.17 and @azure/msal-react to 5.5" (#3139)

### DIFF
--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -8,8 +8,8 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@azure/msal-browser": "^5.17.0",
-        "@azure/msal-react": "^5.5.2",
+        "@azure/msal-browser": "^4.16.0",
+        "@azure/msal-react": "^3.0.16",
         "@fluentui/react-components": "^9.73.3",
         "@fluentui/react-icons": "^2.0.319",
         "@fluentui/react-table": "^9.19.14",
@@ -49,37 +49,37 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.17.0.tgz",
-      "integrity": "sha512-/yTnW2TCk9Mh+2b/NOaHAN+MryUNxzRTaJD/YtrqOA9bpBWfTXn/iyReRbaLrK/btBo3stEzLyEvuWp2NZ5DuA==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.16.0.tgz",
+      "integrity": "sha512-yF8gqyq7tVnYftnrWaNaxWpqhGQXoXpDfwBtL7UCGlIbDMQ1PUJF/T2xCL6NyDNHoO70qp1xU8GjjYTyNIefkw==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.11.1"
+        "@azure/msal-common": "15.9.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "16.11.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.1.tgz",
-      "integrity": "sha512-yPohvMwWLv1XnaWnIUyKUh8CvcVChCGqG/VluGwfGmaAfrZTNt5yQ+sIs462Sgw6+e2K83KGmMJ860p73ZSCrw==",
+      "version": "15.9.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.9.0.tgz",
+      "integrity": "sha512-lbz/D+C9ixUG3hiZzBLjU79a0+5ZXCorjel3mwXluisKNH0/rOS/ajm8yi4yI9RP5Uc70CAcs9Ipd0051Oh/kA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-react": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-5.5.2.tgz",
-      "integrity": "sha512-gqLSay+1NfOjDUNL/A64myLhbPck/ne8Gw6O4Yb14Y/U/7AntnJs1Fzwyxt5AxOMnBkfzl9loDpBas2fugkwXw==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-3.0.16.tgz",
+      "integrity": "sha512-fIFc3z9UrHoOCG4rApNWMRr83DnQlo+CHfLSPNBQa4rndIkr+XYBpdYDqlzqtmikRf3A+CYNVOQ+lQX6jM0zdw==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=10"
       },
       "peerDependencies": {
-        "@azure/msal-browser": "^5.17.0",
-        "react": "^16.8.0 || ^17 || ^18 || ^19.2.1"
+        "@azure/msal-browser": "^4.16.0",
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@babel/runtime": {

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -13,8 +13,8 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "@azure/msal-browser": "^5.17.0",
-    "@azure/msal-react": "^5.5.2",
+    "@azure/msal-browser": "^4.16.0",
+    "@azure/msal-react": "^3.0.16",
     "@fluentui/react-components": "^9.73.3",
     "@fluentui/react-icons": "^2.0.319",
     "@fluentui/react-table": "^9.19.14",


### PR DESCRIPTION
## Purpose

Reverts #3139 (`chore(deps): upgrade @azure/msal-browser to 5.17 and @azure/msal-react to 5.5`).

The msal-browser 5.x upgrade replaced the classic "parent polls `popup.location.href`" handshake with a `BroadcastChannel` bridge that requires a dedicated redirect-bridge page at `/redirect`. Our existing backend served `/redirect` as an empty page (which was the correct pattern for msal-browser 4.x URL polling), so after #3139 merged, popup login was silently broken in local dev and would have been broken on any deploy where the popup flow is actually exercised.

Reverting here **only** so that #3148 can re-apply the upgrade bundled with the redirect-bridge fix, so users never land on a `git pull` state where local login is broken.

**Do not merge #3148 until this is merged**, then #3148 will bundle the msal-browser 5.x re-upgrade atomically with the fix.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

Reverts a same-day merge; nothing else has landed against msal-browser 5.x yet.

## Does this require changes to learn.microsoft.com docs?

```
[ ] Yes
[x] No
```

## Type of change

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

- [x] The current tests all pass — no code changed, only lockfile.
- [x] I added tests that prove my fix is effective or that my feature works — N/A, revert.
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines — N/A.
- [x] I ran `ty check` to check for type errors — N/A.
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.